### PR TITLE
feat: add izzy's NonFreeComp anti-feature

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/app_detail/AppDetailAdapter.kt
@@ -715,6 +715,9 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 					"NonFreeNet" -> context.getString(stringRes.promotes_non_free_network_services)
 					"Tracking" -> context.getString(stringRes.tracks_or_reports_your_activity)
 					"UpstreamNonFree" -> context.getString(stringRes.upstream_source_code_is_not_free)
+					// special tag for IzzyOnDroid (https://floss.social/@IzzyOnDroid/110815951568369581):
+					// apps include non-free libraries
+					"NonFreeComp" -> context.getString(stringRes.has_non_free_components)
 					else -> context.getString(stringRes.unknown_FORMAT, it)
 				}
 			}.joinToString(separator = "\n") { "\u2022 $it" }

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -56,6 +56,7 @@
     <string name="force_clean_up_DESC">Cleans up redundant files</string>
     <string name="has_advertising">Has advertising</string>
     <string name="has_non_free_dependencies">Has non-free dependencies</string>
+    <string name="has_non_free_components">Has non-free components</string>
     <string name="has_security_vulnerabilities">Has security vulnerabilities</string>
     <plurals name="hours">
         <item quantity="one">Hour</item>


### PR DESCRIPTION
Adds support for displaying [IzzyOnDroid's new anti-feature](https://floss.social/@IzzyOnDroid/110815951568369581) `NonFreeComp`.

This anti-featues is for apps which contain non-free dependencies/components (e.g. Google Service library). It is different from `NonFreeDep`, as `NonFreeDep` requires the device to have something installed.

| Before                                                                                                                                                	| After                                                                                                                                       	|
|-------------------------------------------------------------------------------------------------------------------------------------------------------	|---------------------------------------------------------------------------------------------------------------------------------------------	|
| ![Anti-feature list with Unknown anti-feature: NonFreeComp](https://github.com/Droid-ify/client/assets/63370021/3b2a85b7-7b1b-4426-ae57-242a5a3e5407) 	| ![Anti-feature list with Has non-free components](https://github.com/Droid-ify/client/assets/63370021/bc3bbf41-4fc7-4bb5-a7bc-da2585016bf6) 	|
