### PR TITLE
Fix crash on cancelling download

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/service/DownloadService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/service/DownloadService.kt
@@ -136,7 +136,6 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
 		fun cancel(packageName: String) {
 			cancelTasks(packageName)
 			cancelCurrentTask(packageName)
-			handleDownload()
 		}
 	}
 


### PR DESCRIPTION
Repeated calling for `::handleDownload` caused it to take `started` as false