### PR TITLE
Add extension to exported files to allow importing

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
@@ -308,13 +308,13 @@ class SettingsFragment : Fragment() {
                 openImportFileForSettings.launch(arrayOf("application/json"))
             }
             exportSettings.root.setOnClickListener {
-                createExportFileForSettings.launch("droidify_settings")
+                createExportFileForSettings.launch("droidify_settings.json")
             }
             importRepos.root.setOnClickListener {
                 openImportFileForRepos.launch(arrayOf("application/json"))
             }
             exportRepos.root.setOnClickListener {
-                createExportFileForRepos.launch("droidify_repos")
+                createExportFileForRepos.launch("droidify_repos.json")
             }
             creditFoxy.root.setOnClickListener {
                 openLink(FOXY_DROID_URL)


### PR DESCRIPTION
Files without extension are not selectable in import interface of 0.59 Patch 5.