### PR TITLE
Add Cake Labs repository

### DIFF
--- a/core/domain/src/main/kotlin/com/looker/core/domain/Repository.kt
+++ b/core/domain/src/main/kotlin/com/looker/core/domain/Repository.kt
@@ -380,6 +380,12 @@ data class Repository(
                 description = "Monerujo Monero Wallet official F-Droid repository.",
                 fingerprint = "A82C68E14AF0AA6A2EC20E6B272EFF25E5A038F3F65884316E0F5E0D91E7B713"
             ),
+            defaultRepository(
+                address = "https://fdroid.cakelabs.com/fdroid/repo",
+                name = "Cake Labs",
+                description = "Cake Labs official F-Droid repository for Cake Wallet and Monero.com",
+                fingerprint = "EA44EFAEE0B641EE7A032D397D5D976F9C4E5E1ED26E11C75702D064E55F8755"
+            ),
         )
     }
 }


### PR DESCRIPTION
Hi, this is a PR to add the Cake Labs repository to Droid-ify. (https://fdroid.cakelabs.com)

It is the official repository for Cake Wallet and Monero.com wallet.

I did not bump the version number [here](https://github.com/Droid-ify/client/blob/cf2918707404d677fcb2ca9c989edbdf7290350f/app/src/main/kotlin/com/looker/droidify/database/Database.kt#L187) since that number has not been included in a release yet, so I only added the repo to newlyAdded repositories.

Let me know if anything needs to be changed.