### PR TITLE
feat(anti-features): display TetheredNet

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -824,9 +824,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                 "NSFW" -> context.getString(stringRes.contains_nsfw)
                 "Tracking" -> context.getString(stringRes.tracks_or_reports_your_activity)
                 "UpstreamNonFree" -> context.getString(stringRes.upstream_source_code_is_not_free)
-                // special tag(https://floss.social/@IzzyOnDroid/110815951568369581)
+                // special tag (https://floss.social/@IzzyOnDroid/110815951568369581)
                 // apps include non-free libraries
                 "NonFreeComp" -> context.getString(stringRes.has_non_free_components)
+                "TetheredNet" -> context.getString(stringRes.has_tethered_network)
                 else -> context.getString(stringRes.unknown_FORMAT, it)
             }
         }.joinToString(separator = "\n") { "\u2022 $it" }

--- a/core/common/src/main/res/values/strings.xml
+++ b/core/common/src/main/res/values/strings.xml
@@ -68,6 +68,7 @@
     <string name="has_non_free_dependencies">Has non-free dependencies</string>
     <string name="has_non_free_components">Has non-free components</string>
     <string name="has_security_vulnerabilities">Has security vulnerabilities</string>
+    <string name="has_tethered_network">Bound to a certain network service</string>
     <string name="home_screen_swiping">Home Screen Swiping</string>
     <string name="home_screen_swiping_DESC">Allow user to swipe between pages in home screen</string>
     <plurals name="hours">


### PR DESCRIPTION
Adds support for a new anti-feature tag `TetheredNet`. This applies when an app is bound to a specific network services.
[See Untare on IzzyOnDroid for an example](https://apt.izzysoft.de/fdroid/index/apk/unofficial.tandoor.recipes/).