### PR TITLE
Sort repos in alphabetical order

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/database/Database.kt
+++ b/app/src/main/kotlin/com/looker/droidify/database/Database.kt
@@ -47,7 +47,7 @@ object Database {
         val helper = Helper(context)
         db = helper.writableDatabase
         if (helper.created) {
-            for (repository in Repository.defaultRepositories) {
+            for (repository in Repository.defaultRepositories.sortedBy { it.name }) {
                 RepositoryAdapter.put(repository)
             }
         }


### PR DESCRIPTION
Closes #672

F-Droid and IzzyOnDroid are already enabled by default, so I don't think putting them to the top is necessary.
What do you think?

Seems to work fine when tested on Pixel 8 API 34 emulator.
</br>
![Screenshot 2024-04-12 221744](https://github.com/Droid-ify/client/assets/114044633/7770eedb-6f4e-454b-bf13-a735b1b26304)
