### PR TITLE
Add the MM20 Apps repository

### DIFF
--- a/core/domain/src/main/kotlin/com/looker/core/domain/Repository.kt
+++ b/core/domain/src/main/kotlin/com/looker/core/domain/Repository.kt
@@ -392,6 +392,12 @@ data class Repository(
                 description = "FUTO official F-Droid repository.",
                 fingerprint = "39D47869D29CBFCE4691D9F7E6946A7B6D7E6FF4883497E6E675744ECDFA6D6D"
             ),
+            defaultRepository(
+                address = "https://fdroid.mm20.de/repo",
+                name = "MM20 Apps",
+                description = "Apps developed and distributed by MM20",
+                fingerprint = "156FBAB952F6996415F198F3F29628D24B30E725B0F07A2B49C3A9B5161EEE1A"
+            ),
         )
     }
 }


### PR DESCRIPTION
Add the MM20 Apps repository, which contains the Kvaesitso Launcher, (both regular and nightly build) and plugins:

> [Kvaesitso Nightly](https://fdroid.mm20.de/app/de.mm20.launcher2.nightly)
> A search-focused, free and open source launcher for Android
> 
> [Kvaesitso Plugin for Breezy Weather](https://fdroid.mm20.de/app/de.mm20.launcher2.plugin.breezyweather)
> A plugin for Kvaesitso that enables the launcher to use weather data from Breezy
>
> [Kvaesitso Plugin for OneDrive](https://fdroid.mm20.de/app/de.mm20.launcher2.plugin.onedrive)
> A plugin for Kvaesitso that adds OneDrive search support
>
>[Kvaesitso Plugin for OpenWeatherMap](https://fdroid.mm20.de/app/de.mm20.launcher2.plugin.openweathermap)
> OpenWeatherMap provider for Kvaesitso
> 
> [Kvaesitso](https://fdroid.mm20.de/app/de.mm20.launcher2.release)
> A search-focused, free and open source launcher for Android.

It is run by [MM20](https://github.com/mm2-0), the main developer of the Kvaesitso launcher