### PR TITLE
Remove default flags from AGP 8.0

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -14,14 +14,7 @@ org.gradle.daemon=true
 org.gradle.jvmargs=-Xmx6g -Dfile.encoding=UTF-8 -XX:+UseParallelGC -XX:MaxMetaspaceSize=1g
 android.useAndroidX=true
 org.gradle.parallel=true
-android.nonFinalResIds=true
-android.enableJetifier=false
-android.enableR8.fullMode=true
-android.nonTransitiveRClass=true
 org.gradle.caching=true
 org.gradle.configuration-cache=true
-android.defaults.buildfeatures.aidl=false
-android.defaults.buildfeatures.buildconfig=false
-android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false


### PR DESCRIPTION
They are the default from AGP 8, see https://developer.android.com/build/releases/past-releases/agp-8-0-0-release-notes#default-changes.