### PR TITLE
feat: add ability to open app information from Android Settings

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -52,7 +52,9 @@
             android:exported="true"
             android:launchMode="singleTask"
             android:windowSoftInputMode="adjustResize">
-
+            <intent-filter>
+                <action android:name="android.intent.action.SHOW_APP_INFO" />
+            </intent-filter>
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
This fixes #853


As mentioned in #853 the Droid-ify min API Level is 23, and this feature only works on API Level 24 and higher.
I wasn't to test the behavior of this change on API Levels 23 and 24, as I couldn't install an app via Droid-ify, because the CA Certificates are too outdated, on these versions.
