### PR TITLE
Add support for specifying custom installer (`LegacyInstaller` only) 

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
@@ -14,6 +14,7 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.looker.droidify.datastore.model.AutoSync
 import com.looker.droidify.datastore.model.InstallerType
+import com.looker.droidify.datastore.model.LegacyInstallerComponent
 import com.looker.droidify.datastore.model.ProxyPreference
 import com.looker.droidify.datastore.model.ProxyType
 import com.looker.droidify.datastore.model.SortOrder
@@ -85,6 +86,16 @@ class PreferenceSettingsRepository(
     override suspend fun setInstallerType(installerType: InstallerType) =
         INSTALLER_TYPE.update(installerType.name)
 
+    override suspend fun setLegacyInstallerComponent(component: LegacyInstallerComponent?) {
+        if (component == null) {
+            LEGACY_INSTALLER_COMPONENT_CLASS.update("")
+            LEGACY_INSTALLER_COMPONENT_ACTIVITY.update("")
+            return
+        }
+        LEGACY_INSTALLER_COMPONENT_CLASS.update(component.clazz)
+        LEGACY_INSTALLER_COMPONENT_ACTIVITY.update(component.activity)
+    }
+
     override suspend fun setAutoUpdate(allow: Boolean) =
         AUTO_UPDATE.update(allow)
 
@@ -125,6 +136,12 @@ class PreferenceSettingsRepository(
     private fun mapSettings(preferences: Preferences): Settings {
         val installerType =
             InstallerType.valueOf(preferences[INSTALLER_TYPE] ?: InstallerType.Default.name)
+        val legacyInstallerComponent =
+            preferences[LEGACY_INSTALLER_COMPONENT_CLASS]?.takeIf { it.isNotBlank() }?.let { cls ->
+                preferences[LEGACY_INSTALLER_COMPONENT_ACTIVITY]?.takeIf { it.isNotBlank() }?.let { act ->
+                    LegacyInstallerComponent(cls, act)
+                }
+            }
 
         val language = preferences[LANGUAGE] ?: "system"
         val incompatibleVersions = preferences[INCOMPATIBLE_VERSIONS] ?: false
@@ -154,6 +171,7 @@ class PreferenceSettingsRepository(
             theme = theme,
             dynamicTheme = dynamicTheme,
             installerType = installerType,
+            legacyInstallerComponent = legacyInstallerComponent,
             autoUpdate = autoUpdate,
             autoSync = autoSync,
             sortOrder = sortOrder,
@@ -185,6 +203,8 @@ class PreferenceSettingsRepository(
         val LAST_CLEAN_UP = longPreferencesKey("key_last_clean_up_time")
         val FAVOURITE_APPS = stringSetPreferencesKey("key_favourite_apps")
         val HOME_SCREEN_SWIPING = booleanPreferencesKey("key_home_swiping")
+        val LEGACY_INSTALLER_COMPONENT_CLASS = stringPreferencesKey("key_legacy_installer_component_class")
+        val LEGACY_INSTALLER_COMPONENT_ACTIVITY = stringPreferencesKey("key_legacy_installer_component_activity")
 
         // Enums
         val THEME = stringPreferencesKey("key_theme")
@@ -200,6 +220,8 @@ class PreferenceSettingsRepository(
             set(UNSTABLE_UPDATES, settings.unstableUpdate)
             set(THEME, settings.theme.name)
             set(DYNAMIC_THEME, settings.dynamicTheme)
+            settings.legacyInstallerComponent?.let { set(LEGACY_INSTALLER_COMPONENT_CLASS, it.clazz) }
+            settings.legacyInstallerComponent?.let { set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, it.activity) }
             set(INSTALLER_TYPE, settings.installerType.name)
             set(AUTO_UPDATE, settings.autoUpdate)
             set(AUTO_SYNC, settings.autoSync.name)

--- a/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
@@ -87,13 +87,28 @@ class PreferenceSettingsRepository(
         INSTALLER_TYPE.update(installerType.name)
 
     override suspend fun setLegacyInstallerComponent(component: LegacyInstallerComponent?) {
-        if (component == null) {
-            LEGACY_INSTALLER_COMPONENT_CLASS.update("")
-            LEGACY_INSTALLER_COMPONENT_ACTIVITY.update("")
-            return
+        when (component) {
+            null -> {
+                LEGACY_INSTALLER_COMPONENT_TYPE.update("")
+                LEGACY_INSTALLER_COMPONENT_CLASS.update("")
+                LEGACY_INSTALLER_COMPONENT_ACTIVITY.update("")
+            }
+            is LegacyInstallerComponent.Component -> {
+                LEGACY_INSTALLER_COMPONENT_TYPE.update("component")
+                LEGACY_INSTALLER_COMPONENT_CLASS.update(component.clazz)
+                LEGACY_INSTALLER_COMPONENT_ACTIVITY.update(component.activity)
+            }
+            LegacyInstallerComponent.Unspecified -> {
+                LEGACY_INSTALLER_COMPONENT_TYPE.update("unspecified")
+                LEGACY_INSTALLER_COMPONENT_CLASS.update("")
+                LEGACY_INSTALLER_COMPONENT_ACTIVITY.update("")
+            }
+            LegacyInstallerComponent.AlwaysChoose -> {
+                LEGACY_INSTALLER_COMPONENT_TYPE.update("always_choose")
+                LEGACY_INSTALLER_COMPONENT_CLASS.update("")
+                LEGACY_INSTALLER_COMPONENT_ACTIVITY.update("")
+            }
         }
-        LEGACY_INSTALLER_COMPONENT_CLASS.update(component.clazz)
-        LEGACY_INSTALLER_COMPONENT_ACTIVITY.update(component.activity)
     }
 
     override suspend fun setAutoUpdate(allow: Boolean) =
@@ -136,12 +151,18 @@ class PreferenceSettingsRepository(
     private fun mapSettings(preferences: Preferences): Settings {
         val installerType =
             InstallerType.valueOf(preferences[INSTALLER_TYPE] ?: InstallerType.Default.name)
-        val legacyInstallerComponent =
-            preferences[LEGACY_INSTALLER_COMPONENT_CLASS]?.takeIf { it.isNotBlank() }?.let { cls ->
-                preferences[LEGACY_INSTALLER_COMPONENT_ACTIVITY]?.takeIf { it.isNotBlank() }?.let { act ->
-                    LegacyInstallerComponent(cls, act)
+        val legacyInstallerComponent = when (preferences[LEGACY_INSTALLER_COMPONENT_TYPE]) {
+            "component" -> {
+                preferences[LEGACY_INSTALLER_COMPONENT_CLASS]?.takeIf { it.isNotBlank() }?.let { cls ->
+                    preferences[LEGACY_INSTALLER_COMPONENT_ACTIVITY]?.takeIf { it.isNotBlank() }?.let { act ->
+                        LegacyInstallerComponent.Component(cls, act)
+                    }
                 }
             }
+            "unspecified" -> LegacyInstallerComponent.Unspecified
+            "always_choose" -> LegacyInstallerComponent.AlwaysChoose
+            else -> null
+        }
 
         val language = preferences[LANGUAGE] ?: "system"
         val incompatibleVersions = preferences[INCOMPATIBLE_VERSIONS] ?: false
@@ -205,6 +226,7 @@ class PreferenceSettingsRepository(
         val HOME_SCREEN_SWIPING = booleanPreferencesKey("key_home_swiping")
         val LEGACY_INSTALLER_COMPONENT_CLASS = stringPreferencesKey("key_legacy_installer_component_class")
         val LEGACY_INSTALLER_COMPONENT_ACTIVITY = stringPreferencesKey("key_legacy_installer_component_activity")
+        val LEGACY_INSTALLER_COMPONENT_TYPE = stringPreferencesKey("key_legacy_installer_component_type")
 
         // Enums
         val THEME = stringPreferencesKey("key_theme")
@@ -220,8 +242,28 @@ class PreferenceSettingsRepository(
             set(UNSTABLE_UPDATES, settings.unstableUpdate)
             set(THEME, settings.theme.name)
             set(DYNAMIC_THEME, settings.dynamicTheme)
-            settings.legacyInstallerComponent?.let { set(LEGACY_INSTALLER_COMPONENT_CLASS, it.clazz) }
-            settings.legacyInstallerComponent?.let { set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, it.activity) }
+            when (settings.legacyInstallerComponent) {
+                is LegacyInstallerComponent.Component -> {
+                    set(LEGACY_INSTALLER_COMPONENT_TYPE, "component")
+                    set(LEGACY_INSTALLER_COMPONENT_CLASS, settings.legacyInstallerComponent.clazz)
+                    set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, settings.legacyInstallerComponent.activity)
+                }
+                LegacyInstallerComponent.Unspecified -> {
+                    set(LEGACY_INSTALLER_COMPONENT_TYPE, "unspecified")
+                    set(LEGACY_INSTALLER_COMPONENT_CLASS, "")
+                    set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, "")
+                }
+                LegacyInstallerComponent.AlwaysChoose -> {
+                    set(LEGACY_INSTALLER_COMPONENT_TYPE, "always_choose")
+                    set(LEGACY_INSTALLER_COMPONENT_CLASS, "")
+                    set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, "")
+                }
+                null -> {
+                    set(LEGACY_INSTALLER_COMPONENT_TYPE, "")
+                    set(LEGACY_INSTALLER_COMPONENT_CLASS, "")
+                    set(LEGACY_INSTALLER_COMPONENT_ACTIVITY, "")
+                }
+            }
             set(INSTALLER_TYPE, settings.installerType.name)
             set(AUTO_UPDATE, settings.autoUpdate)
             set(AUTO_SYNC, settings.autoSync.name)

--- a/app/src/main/kotlin/com/looker/droidify/datastore/Settings.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/Settings.kt
@@ -3,6 +3,7 @@ package com.looker.droidify.datastore
 import androidx.datastore.core.Serializer
 import com.looker.droidify.datastore.model.AutoSync
 import com.looker.droidify.datastore.model.InstallerType
+import com.looker.droidify.datastore.model.LegacyInstallerComponent
 import com.looker.droidify.datastore.model.ProxyPreference
 import com.looker.droidify.datastore.model.SortOrder
 import com.looker.droidify.datastore.model.Theme
@@ -29,6 +30,7 @@ data class Settings(
     val theme: Theme = Theme.SYSTEM,
     val dynamicTheme: Boolean = false,
     val installerType: InstallerType = InstallerType.Default,
+    val legacyInstallerComponent: LegacyInstallerComponent? = null,
     val autoUpdate: Boolean = false,
     val autoSync: AutoSync = AutoSync.WIFI_ONLY,
     val sortOrder: SortOrder = SortOrder.UPDATED,

--- a/app/src/main/kotlin/com/looker/droidify/datastore/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/SettingsRepository.kt
@@ -3,6 +3,7 @@ package com.looker.droidify.datastore
 import android.net.Uri
 import com.looker.droidify.datastore.model.AutoSync
 import com.looker.droidify.datastore.model.InstallerType
+import com.looker.droidify.datastore.model.LegacyInstallerComponent
 import com.looker.droidify.datastore.model.ProxyType
 import com.looker.droidify.datastore.model.SortOrder
 import com.looker.droidify.datastore.model.Theme
@@ -36,6 +37,8 @@ interface SettingsRepository {
     suspend fun setDynamicTheme(enable: Boolean)
 
     suspend fun setInstallerType(installerType: InstallerType)
+
+    suspend fun setLegacyInstallerComponent(component: LegacyInstallerComponent?)
 
     suspend fun setAutoUpdate(allow: Boolean)
 

--- a/app/src/main/kotlin/com/looker/droidify/datastore/model/LegacyInstallerComponent.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/model/LegacyInstallerComponent.kt
@@ -1,0 +1,17 @@
+package com.looker.droidify.datastore.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LegacyInstallerComponent(
+    val clazz: String,
+    val activity: String,
+) {
+    fun update(
+        newClazz: String? = null,
+        newActivity: String? = null,
+    ): LegacyInstallerComponent = copy(
+        clazz = newClazz ?: clazz,
+        activity = newActivity ?: activity
+    )
+}

--- a/app/src/main/kotlin/com/looker/droidify/datastore/model/LegacyInstallerComponent.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/model/LegacyInstallerComponent.kt
@@ -3,15 +3,24 @@ package com.looker.droidify.datastore.model
 import kotlinx.serialization.Serializable
 
 @Serializable
-data class LegacyInstallerComponent(
-    val clazz: String,
-    val activity: String,
-) {
-    fun update(
-        newClazz: String? = null,
-        newActivity: String? = null,
-    ): LegacyInstallerComponent = copy(
-        clazz = newClazz ?: clazz,
-        activity = newActivity ?: activity
-    )
+sealed class LegacyInstallerComponent {
+    @Serializable
+    object Unspecified : LegacyInstallerComponent()
+
+    @Serializable
+    object AlwaysChoose : LegacyInstallerComponent()
+
+    @Serializable
+    data class Component(
+        val clazz: String,
+        val activity: String,
+    ) : LegacyInstallerComponent() {
+        fun update(
+            newClazz: String? = null,
+            newActivity: String? = null,
+        ): Component = copy(
+            clazz = newClazz ?: clazz,
+            activity = newActivity ?: activity
+        )
+    }
 }

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -32,7 +32,7 @@ import kotlinx.coroutines.sync.withLock
 
 class InstallManager(
     private val context: Context,
-    settingsRepository: SettingsRepository
+    private val settingsRepository: SettingsRepository
 ) {
 
     private val installItems = Channel<InstallItem>()
@@ -115,7 +115,7 @@ class InstallManager(
     private suspend fun setInstaller(installerType: InstallerType) {
         lock.withLock {
             _installer = when (installerType) {
-                InstallerType.LEGACY -> LegacyInstaller(context)
+                InstallerType.LEGACY -> LegacyInstaller(context, settingsRepository)
                 InstallerType.SESSION -> SessionInstaller(context)
                 InstallerType.SHIZUKU -> ShizukuInstaller(context)
                 InstallerType.ROOT -> RootInstaller(context)

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/LegacyInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/LegacyInstaller.kt
@@ -1,20 +1,25 @@
 package com.looker.droidify.installer.installers
 
+import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.util.AndroidRuntimeException
 import androidx.core.net.toUri
+import com.looker.droidify.datastore.SettingsRepository
+import com.looker.droidify.datastore.get
 import com.looker.droidify.domain.model.PackageName
 import com.looker.droidify.installer.model.InstallItem
 import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.utility.common.SdkCheck
 import com.looker.droidify.utility.common.cache.Cache
 import com.looker.droidify.utility.common.extension.intent
+import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
 
 @Suppress("DEPRECATION")
-class LegacyInstaller(private val context: Context) : Installer {
+class LegacyInstaller(private val context: Context,
+                      private val settingsRepository: SettingsRepository) : Installer {
 
     companion object {
         private const val APK_MIME = "application/vnd.android.package-archive"
@@ -22,29 +27,37 @@ class LegacyInstaller(private val context: Context) : Installer {
 
     override suspend fun install(
         installItem: InstallItem,
-    ): InstallState = suspendCancellableCoroutine { cont ->
+    ): InstallState {
         val installFlag = if (SdkCheck.isNougat) Intent.FLAG_GRANT_READ_URI_PERMISSION else 0
         val fileUri = if (SdkCheck.isNougat) {
-            Cache.getReleaseUri(
-                context,
-                installItem.installFileName
-            )
+            Cache.getReleaseUri(context, installItem.installFileName)
         } else {
             Cache.getReleaseFile(context, installItem.installFileName).toUri()
         }
-        val installIntent = intent(Intent.ACTION_INSTALL_PACKAGE) {
-            setDataAndType(fileUri, APK_MIME)
-            flags = installFlag
-        }
-        try {
-            context.startActivity(installIntent)
-            cont.resume(InstallState.Installed)
-        } catch (e: AndroidRuntimeException) {
-            installIntent.flags = installFlag or Intent.FLAG_ACTIVITY_NEW_TASK
-            context.startActivity(installIntent)
-            cont.resume(InstallState.Installed)
-        } catch (e: Exception) {
-            cont.resume(InstallState.Failed)
+
+        val comp = settingsRepository.get { legacyInstallerComponent }.firstOrNull()
+
+        return suspendCancellableCoroutine { cont ->
+            val installIntent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
+                setDataAndType(fileUri, APK_MIME)
+                flags = installFlag
+                component = comp?.let { ComponentName(it.clazz, it.activity) }
+            }
+
+            try {
+                context.startActivity(installIntent)
+                cont.resume(InstallState.Installed)
+            } catch (e: AndroidRuntimeException) {
+                installIntent.flags = installFlag or Intent.FLAG_ACTIVITY_NEW_TASK
+                try {
+                    context.startActivity(installIntent)
+                    cont.resume(InstallState.Installed)
+                } catch (e: Exception) {
+                    cont.resume(InstallState.Failed)
+                }
+            } catch (e: Exception) {
+                cont.resume(InstallState.Failed)
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
@@ -2,6 +2,7 @@ package com.looker.droidify.ui.settings
 
 import android.content.Context
 import android.content.Intent
+import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Bundle
 import android.view.LayoutInflater
@@ -36,6 +37,7 @@ import com.looker.droidify.datastore.extension.themeName
 import com.looker.droidify.datastore.extension.toTime
 import com.looker.droidify.datastore.model.AutoSync
 import com.looker.droidify.datastore.model.InstallerType
+import com.looker.droidify.datastore.model.LegacyInstallerComponent
 import com.looker.droidify.datastore.model.ProxyType
 import com.looker.droidify.datastore.model.Theme
 import com.looker.droidify.utility.common.SdkCheck
@@ -53,6 +55,7 @@ import kotlin.time.Duration
 import kotlin.time.Duration.Companion.days
 import kotlin.time.Duration.Companion.hours
 import com.google.android.material.R as MaterialR
+import androidx.core.net.toUri
 
 @AndroidEntryPoint
 class SettingsFragment : Fragment() {
@@ -230,6 +233,47 @@ class SettingsFragment : Fragment() {
                     onClick = { viewModel.setInstaller(requireContext(), it) }
                 )
             }
+            val pm = requireContext().packageManager
+            legacyInstallerComponent.connect(
+                titleText = getString(R.string.legacyInstallerComponent),
+                setting = viewModel.getSetting { legacyInstallerComponent },
+                map = {
+                    it?.let { component ->
+                        val appLabel = runCatching {
+                            val info = pm.getApplicationInfo(component.clazz, 0)
+                            pm.getApplicationLabel(info).toString()
+                        }.getOrElse { component.clazz }
+                        "$appLabel (${component.activity})"
+                    } ?: getString(R.string.unspecified)
+                },
+            ) { component, valueToString ->
+                val installerOptions = run {
+                    var contentProtocol = "content://"
+                    val intent = Intent(Intent.ACTION_INSTALL_PACKAGE).apply {
+                        setDataAndType(contentProtocol.toUri(), "application/vnd.android.package-archive")
+                    }
+                    val activities = pm.queryIntentActivities(intent, PackageManager.MATCH_DEFAULT_ONLY)
+                    listOf<LegacyInstallerComponent?>(null) + activities.map {
+                        LegacyInstallerComponent(
+                            clazz = it.activityInfo.packageName,
+                            activity = it.activityInfo.name,
+                        )
+                    }
+                }
+                addSingleCorrectDialog(
+                    initialValue = component,
+                    values = installerOptions,
+                    title = R.string.legacyInstallerComponent,
+                    iconRes = R.drawable.ic_apk_install,
+                    valueToString = valueToString,
+                    onClick = { viewModel.setLegacyInstallerComponentComponent(it) },
+                )
+            }
+            incompatibleUpdates.connect(
+                titleText = getString(R.string.incompatible_versions),
+                contentText = getString(R.string.incompatible_versions_summary),
+                setting = viewModel.getInitialSetting { incompatibleVersions },
+            )
             proxyType.connect(
                 titleText = getString(R.string.proxy_type),
                 setting = viewModel.getSetting { proxy.type },
@@ -389,6 +433,9 @@ class SettingsFragment : Fragment() {
             proxyHost.root.isVisible = allowProxies
             proxyPort.root.isVisible = allowProxies
             forceCleanUp.root.isVisible = settings.cleanUpInterval == Duration.INFINITE
+
+            val useLegacyInstaller = settings.installerType == InstallerType.LEGACY
+            legacyInstallerComponent.root.isVisible = useLegacyInstaller
         }
     }
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsViewModel.kt
@@ -17,6 +17,7 @@ import com.looker.droidify.datastore.model.AutoSync
 import com.looker.droidify.datastore.model.InstallerType
 import com.looker.droidify.datastore.model.InstallerType.ROOT
 import com.looker.droidify.datastore.model.InstallerType.SHIZUKU
+import com.looker.droidify.datastore.model.LegacyInstallerComponent
 import com.looker.droidify.datastore.model.ProxyType
 import com.looker.droidify.datastore.model.Theme
 import com.looker.droidify.installer.installers.isMagiskGranted
@@ -188,6 +189,12 @@ class SettingsViewModel
                     settingsRepository.setInstallerType(installerType)
                 }
             }
+        }
+    }
+
+    fun setLegacyInstallerComponentComponent(component: LegacyInstallerComponent?) {
+        viewModelScope.launch {
+            settingsRepository.setLegacyInstallerComponent(component)
         }
     }
 

--- a/app/src/main/res/layout/settings_page.xml
+++ b/app/src/main/res/layout/settings_page.xml
@@ -145,6 +145,9 @@
             <include
                 android:id="@+id/installer"
                 layout="@layout/enum_type" />
+            <include
+                android:id="@+id/legacy_installer_component"
+                layout="@layout/enum_type" />
 
             <TextView
                 android:layout_width="match_parent"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -241,4 +241,6 @@
     <string name="label_open_video">Video</string>
     <string name="label_targets_sdk">Targets: Android %s</string>
     <string name="label_unknown_sdk">Unknown (%d)</string>
+    <string name="always_choose">Always Choose</string>
+    <string name="select_installer">Select installer</string>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -103,12 +103,15 @@
     <string name="install">Install</string>
     <string name="install_types">Installation Types</string>
     <string name="installer">Installer</string>
+    <string name="legacyInstallerComponent">Legacy Installer Component</string>
+    <string name="unspecified">Unspecified</string>
     <string name="insufficient_storage">Insufficient Space</string>
     <string name="insufficient_storage_DESC">There is not enough free space on the device to install this application. Try clearing some space</string>
     <string name="legacy_installer">Legacy Installer</string>
     <string name="session_installer">Session Installer</string>
     <string name="root_installer">Root Installer</string>
     <string name="shizuku_installer">Shizuku Installer</string>
+    <string name="shizuku_legacy_installer">Shizuku Legacy Installer</string>
     <string name="shizuku_not_alive">Shizuku is not running</string>
     <string name="shizuku_not_installed">Shizuku is not installed</string>
     <string name="installed">Installed</string>


### PR DESCRIPTION
## Description
Introduced a new setting for custom installer configuration, which is only enabled when using the Legacy Installer. This allows specifying the package name in the Intent.

## Usage

This can be particularly useful when you want to install apps into a specific work profile or invoke a third-party installer, such as:

1. Calling _Island_ to install into a designated profile #718 
2. Invoking third-party installers like _InstallerX_[^1] or _Install With Options_; Namely, _InstallerX_ supports various installation authorization modes, such as _Shizuku_ and _Dhizuku_[^2], and allows customization of other authorization methods (if available). I believe this can actually serve as a workaround mentioned in #937 and #964.  
 
[^1]: Some device manufacturers prevent changing the default installer and block ADB installation. In such cases, _Dhizuku's_ Device Owner permission can be very useful.

## Demo

https://github.com/user-attachments/assets/ee64a594-18ad-4c0d-8701-2cafa7fedaa3

> As shown in the video, the first half demonstrates installation using _Shizuku_, but the system intercepts it, showing an annoying installation prompt along with scanning and ads.  
> In contrast, the second half uses _InstallerX_ in _Dhizuku_ mode, which avoids these issues.


