### PR TITLE
Replace the (301) `Iamlooker/Droid-ify` URI with `Droid-ify/client` in `SettingsFragment.kt`.

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
@@ -75,7 +75,7 @@ class SettingsFragment : Fragment() {
         private const val FOXY_DROID_URL = "https://github.com/kitsunyan/foxy-droid"
 
         private const val DROID_IFY_TITLE = "Droid-ify"
-        private const val DROID_IFY_URL = "https://github.com/Iamlooker/Droid-ify"
+        private const val DROID_IFY_URL = "https://github.com/Droid-ify/client"
     }
 
     private val viewModel: SettingsViewModel by viewModels()


### PR DESCRIPTION
Remediates https://github.com/Droid-ify/client/issues/1015#issue-3147577598.