### PR TITLE
Add missing sdk names

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/utility/common/SdkCheck.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/common/SdkCheck.kt
@@ -36,6 +36,21 @@ object SdkCheck {
 
 val sdkName by lazy {
     mapOf(
+        1 to "1.0"
+        2 to "1.1"
+        3 to "1.5"
+        4 to "1.6"
+        5 to "2.0"
+        6 to "2.0.1"
+        7 to "2.1"
+        8 to "2.2"
+        9 to "2.3.0"
+        10 to "2.3.3"
+        11 to "3.0"
+        12 to "3.1"
+        13 to "3.2"
+        14 to "4.0.1"
+        15 to "4.0.3"
         16 to "4.1",
         17 to "4.2",
         18 to "4.3",


### PR DESCRIPTION
Hi :)

So, I'm not 100% sure if this is the correct fix as I'm having trouble building Droid-ify locally (my Android Studio setup [has become a mess](https://xkcd.com/1987/) over the years), but looking through the code I'm *fairly* sure.

I took the version codes from https://apilevels.com/. In the case the versions mentioned a range, I used the lowest version name (2.3.3 - 2.3.7 = 2.3.3 for example).

I'm hoping this should fix KeepassDX being marked as having "Android Unknown" as minimum version due to using minSdk 15 (https://github.com/Kunzisoft/KeePassDX/blob/70665f110da9949b097fe5cbae5ae0c45d906981/app/build.gradle#L12):
<img width="575" height="1280" alt="image" src="https://github.com/user-attachments/assets/4ccbd386-0c53-4b69-b58a-47c782d8c0f7" />

Hope this helps :)