### PR TITLE
feat: support archiving apps

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -183,6 +183,14 @@
             android:authorities="${applicationId}.androidx-startup"
             tools:node="remove" />
 
+        <receiver
+            android:name=".receivers.UnarchivePackageReceiver"
+            android:exported="false">
+            <intent-filter>
+                <action android:name="android.intent.action.UNARCHIVE_PACKAGE" />
+            </intent-filter>
+        </receiver>
+
     </application>
 
 </manifest>

--- a/app/src/main/kotlin/com/looker/droidify/database/Database.kt
+++ b/app/src/main/kotlin/com/looker/droidify/database/Database.kt
@@ -476,6 +476,21 @@ object Database {
             ).use { it.asSequence().map(::transform).toList() }
         }
 
+        fun getArchivedApp(packageName: String): List<Product> {
+            return db.query(
+                Schema.Product.name,
+                columns = arrayOf(
+                    Schema.Product.ROW_REPOSITORY_ID,
+                    Schema.Product.ROW_DESCRIPTION,
+                    Schema.Product.ROW_DATA,
+                    Schema.Product.ROW_COMPATIBLE,
+                    Schema.Product.ROW_SIGNATURES,
+                    Schema.Product.ROW_VERSION_CODE,
+                ),
+                selection = Pair("${Schema.Product.ROW_PACKAGE_NAME} = ?", arrayOf(packageName)),
+            ).use { it.asSequence().map(::transform).toList() }
+        }
+
         fun getCountStream(repositoryId: Long): Flow<Int> = flowOf(Unit)
             .onCompletion { if (it == null) emitAll(flowCollection(Subject.Products)) }
             .map { getCount(repositoryId) }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/session/SessionInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/session/SessionInstaller.kt
@@ -43,6 +43,10 @@ class SessionInstaller(private val context: Context) : Installer {
         installItem: InstallItem
     ): InstallState = suspendCancellableCoroutine { cont ->
         val cacheFile = Cache.getReleaseFile(context, installItem.installFileName)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.VANILLA_ICE_CREAM && installItem.unarchiveId != null) {
+            sessionParams.setUnarchiveId(installItem.unarchiveId)
+        }
+
         val id = installer.createSession(sessionParams)
         val installerCallback = object : PackageInstaller.SessionCallback() {
             override fun onCreated(sessionId: Int) {}

--- a/app/src/main/kotlin/com/looker/droidify/installer/model/InstallItem.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/model/InstallItem.kt
@@ -5,7 +5,8 @@ import com.looker.droidify.domain.model.toPackageName
 
 class InstallItem(
     val packageName: PackageName,
-    val installFileName: String
+    val installFileName: String,
+    val unarchiveId: Int? = null
 )
 
 infix fun String.installFrom(fileName: String) = InstallItem(this.toPackageName(), fileName)

--- a/app/src/main/kotlin/com/looker/droidify/receivers/UnarchivePackageReceiver.kt
+++ b/app/src/main/kotlin/com/looker/droidify/receivers/UnarchivePackageReceiver.kt
@@ -1,0 +1,36 @@
+package com.looker.droidify.receivers
+
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.Intent.ACTION_UNARCHIVE_PACKAGE
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_ALL_USERS
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_ID
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_PACKAGE_NAME
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import com.looker.droidify.work.UnarchiveWorker
+import dagger.hilt.android.AndroidEntryPoint
+
+private val TAG = UnarchivePackageReceiver::class.java.simpleName
+
+// Port from https://gitlab.com/fdroid/fdroidclient/-/merge_requests/1436
+
+@AndroidEntryPoint
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+class UnarchivePackageReceiver : BroadcastReceiver() {
+    override fun onReceive(context: Context, intent: Intent) {
+        if (intent.action != ACTION_UNARCHIVE_PACKAGE) {
+            Log.w(TAG, "Unknown action: ${intent.action}")
+            return
+        }
+        val packageName = intent.getStringExtra(EXTRA_UNARCHIVE_PACKAGE_NAME) ?: error("")
+        val unarchiveId = intent.getIntExtra(EXTRA_UNARCHIVE_ID, -1)
+        val allUsers = intent.getBooleanExtra(EXTRA_UNARCHIVE_ALL_USERS, false)
+
+        Log.i(TAG, "Intent received, un-archiving $packageName...")
+
+        UnarchiveWorker.updateNow(context, packageName, unarchiveId, allUsers)
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/work/UnarchiveWorker.kt
+++ b/app/src/main/kotlin/com/looker/droidify/work/UnarchiveWorker.kt
@@ -1,0 +1,136 @@
+package com.looker.droidify.work
+
+import android.content.Context
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_ALL_USERS
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_ID
+import android.content.pm.PackageInstaller.EXTRA_UNARCHIVE_PACKAGE_NAME
+import android.content.pm.PackageManager
+import android.content.pm.PackageManager.MATCH_ARCHIVED_PACKAGES
+import android.os.Build
+import android.util.Log
+import androidx.annotation.RequiresApi
+import androidx.hilt.work.HiltWorker
+import androidx.work.CoroutineWorker
+import androidx.work.Data
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import androidx.work.WorkerParameters
+import com.looker.droidify.database.Database
+import com.looker.droidify.datastore.SettingsRepository
+import com.looker.droidify.domain.model.PackageName
+import com.looker.droidify.installer.InstallManager
+import com.looker.droidify.installer.model.InstallItem
+import com.looker.droidify.model.Product
+import com.looker.droidify.model.Repository
+import com.looker.droidify.service.Connection
+import com.looker.droidify.service.DownloadService
+import com.looker.droidify.utility.common.extension.calculateHash
+import com.looker.droidify.utility.common.extension.singleSignature
+import dagger.assisted.Assisted
+import dagger.assisted.AssistedInject
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.last
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlinx.coroutines.withContext
+import javax.inject.Inject
+
+@HiltWorker
+@RequiresApi(Build.VERSION_CODES.VANILLA_ICE_CREAM)
+class UnarchiveWorker @AssistedInject constructor(
+    @Assisted context: Context,
+    @Assisted workerParams: WorkerParameters,
+    private val installManager: InstallManager
+) : CoroutineWorker(context, workerParams) {
+    companion object {
+        private const val TAG = "CleanUpWorker"
+
+        fun updateNow(context: Context, packageName: String, unarchiveId: Int, allUsers: Boolean) {
+            val data = Data.Builder()
+                .putString(EXTRA_UNARCHIVE_PACKAGE_NAME, packageName)
+                .putInt(EXTRA_UNARCHIVE_ID, unarchiveId)
+                .putBoolean(EXTRA_UNARCHIVE_ALL_USERS, allUsers)
+                .build()
+            val workRequest = OneTimeWorkRequestBuilder<UnarchiveWorker>()
+                .setInputData(data)
+                .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+                .build()
+            WorkManager.getInstance(context).enqueue(workRequest)
+        }
+    }
+
+    suspend fun downloadProductAndWait(
+        context: Context,
+        packageName: String,
+        product: Product,
+        repository: Repository
+    ): DownloadService.DownloadState {
+        lateinit var connection: Connection<DownloadService.Binder, DownloadService>
+        val binder = suspendCancellableCoroutine { cont ->
+            val c = Connection(
+                serviceClass = DownloadService::class.java,
+                onBind = { _, binder ->
+                    cont.resume(binder) { cause, _, _ -> connection.unbind(context) }
+                }
+            )
+            connection = c
+            c.bind(context)
+        }
+
+        binder.enqueue(
+            packageName,
+            product.name,
+            repository,
+            product.releases.first()
+        )
+
+        // Wait until the download completes
+        val downloadResult = binder.downloadState.last()
+        connection.unbind(context)
+        return downloadResult
+    }
+
+    override suspend fun doWork(): Result = withContext(Dispatchers.IO) {
+        val packageName = inputData.getString(EXTRA_UNARCHIVE_PACKAGE_NAME) ?: return@withContext Result.failure()
+        val unarchiveId = inputData.getInt(EXTRA_UNARCHIVE_ID, -1)
+
+        val packageManger = applicationContext.packageManager
+        val packageInfo = packageManger.getPackageInfo(
+            packageName,
+            PackageManager.PackageInfoFlags.of(MATCH_ARCHIVED_PACKAGES)
+        )
+        val sig = packageInfo.singleSignature?.calculateHash()
+
+        val product = Database.ProductAdapter.getArchivedApp(packageName)
+            .filter { it.compatible && (sig == null || it.signatures.contains(sig)) }
+            .maxByOrNull { it.versionCode }
+        if (product == null) {
+            Log.e(TAG, "doWork: failed to find a matching app for $packageName")
+            return@withContext Result.failure()
+        }
+        val repository = Database.RepositoryAdapter.get(product.repositoryId)
+            ?: return@withContext Result.failure()
+
+
+        val result = downloadProductAndWait(applicationContext,
+            packageName,
+            product,
+            repository,
+        )
+
+        if (result.currentItem !is DownloadService.State.Success) {
+            Log.e(TAG, "doWork: failed to download ", )
+            return@withContext Result.failure()
+        }
+
+        installManager.install(
+            InstallItem(
+                PackageName(packageName),
+                result.currentItem.release.cacheFileName,
+                unarchiveId,
+            )
+        )
+        Result.success()
+    }
+}


### PR DESCRIPTION
Implements support for archiving and unarchiving apps, an Android 15 feature, where the user can remove the application, whilst keeping the data with the option to easily restore the app.

### Notes
- Currently this always shows a notification to 'Tap to Install'
- Probably requires some more testing

Closes: https://github.com/Droid-ify/client/issues/842