### PR TITLE
Truncate files when exporting settings and repositories

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/database/RepositoryExporter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/database/RepositoryExporter.kt
@@ -31,7 +31,7 @@ class RepositoryExporter @Inject constructor(
 ) : Exporter<List<Repository>> {
     override suspend fun export(item: List<Repository>, target: Uri) {
         scope.launch(ioDispatcher) {
-            val stream = context.contentResolver.openOutputStream(target)
+            val stream = context.contentResolver.openOutputStream(target, "wt")
             Json.factory.createGenerator(stream).use { generator ->
                 generator.writeDictionary {
                     writeArray("repositories") {

--- a/app/src/main/kotlin/com/looker/droidify/datastore/exporter/SettingsExporter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/exporter/SettingsExporter.kt
@@ -27,7 +27,7 @@ class SettingsExporter(
     override suspend fun export(item: Settings, target: Uri) {
         scope.launch(ioDispatcher) {
             try {
-                context.contentResolver.openOutputStream(target).use {
+                context.contentResolver.openOutputStream(target, "wt").use {
                     if (it != null) json.encodeToStream(item, it)
                 }
             } catch (e: SerializationException) {


### PR DESCRIPTION
Without this, if the user chooses to overwrite an existing file when exporting and the new export is smaller than the old export, the resulting file will be corrupted due to leftover old data at the end.