### PR TITLE
add cert pinning for nine f-droid repositories

### DIFF
--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -9,4 +9,51 @@
             <certificates src="user" />
         </trust-anchors>
     </base-config>
+
+    <!-- cert pinning for domains with Let's Encrypt / ISRG as CA -->
+    <!-- last update: 2025-11-16 -->
+    <!-- https://letsencrypt.org/certificates
+     Intermidiate certs: "Subordinate (Intermediate) CAs" section
+     CAs for subscriber certificates with RSA public keys: R11, R12, R13 ...
+     CAs for subscriber certificates with ECDSA public keys: E7, E8, E9 ...
+     For better compatibility better to add cert pinning on BOTH 'E' and 'R' CA including current and upcoming
+     -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">f-droid.org</domain>
+        <domain includeSubdomains="false">guardianproject.info</domain>
+        <domain includeSubdomains="false">apt.izzysoft.de</domain>
+        <domain includeSubdomains="false">app.futo.org</domain>
+        <domain includeSubdomains="false">molly.im</domain>
+        <domain includeSubdomains="false">app.simplex.chat</domain>
+        <domain includeSubdomains="false">briarproject.org</domain>
+        <domain includeSubdomains="false">microg.org</domain>
+        <domain includeSubdomains="false">cdn.kde.org</domain>
+        <!-- expiration = most later expiration for listed down pins -->
+        <pin-set expiration="2028-09-02">
+            <!-- currently used by LE : E7, E8, R12, R13 -->
+            <!-- TODO: expire at 2027-03-12 -->
+            <pin digest="SHA-256">y7xVm0TVJNahMr2sZydE2jQH8SquXV9yLF9seROHHHU=</pin>
+            <pin digest="SHA-256">iFvwVyJSxnQdyaUvUERIf+8qk7gRze3612JMwoO3zdU=</pin>
+            <pin digest="SHA-256">kZwN96eHtZftBWrOZUsd6cA4es80n3NzSk/XtYz2EqQ=</pin>
+            <pin digest="SHA-256">AlSQhgtJirc8ahLyekmtX+Iw+v46yPYRLJt9Cq1GlB0=</pin>
+            <!-- backup used by LE : E9, R14 -->
+            <!-- TODO: expire at 2027-03-12 -->
+            <pin digest="SHA-256">8UQKm3bh5B5TpMtGEym/Yze0GXJr5RPkLhnxxpHF1LI=</pin>
+            <pin digest="SHA-256">8WR6XuPvrFTIkukwWE/keXm3rNHHbBJxvKHFB22GmIg=</pin>
+            <!-- retired BUT valid by LE : E5, E6, R10, R11 -->
+            <!-- TODO: expire at 2027-03-12 -->
+            <pin digest="SHA-256">NYbU7PBwV4y9J67c4guWTki8FJ+uudrXL0a4V4aRcrg=</pin>
+            <pin digest="SHA-256">0Bbh/jEZSKymTy3kTOhsmlHKBB32EDu1KojrP3YfV9c=</pin>
+            <pin digest="SHA-256">K7rZOrXHknnsEhUH8nLL4MZkejquUuIvOIr6tCa0rbo=</pin>
+            <pin digest="SHA-256">bdrBhpj38ffhxpubzkINl0rG+UyossdhcBYj+Zx2fcc=</pin>
+            <!-- upcoming by LE : YE1, YE2, YE3, YR1, YR2, YR3 -->
+            <!-- TODO: expire at 2028-09-02 -->
+            <pin digest="SHA-256">brzvtCELCIZUo4sD/qPX0ccRtPsd3DY6RfmxpOU9oB4=</pin>
+            <pin digest="SHA-256">s/tdAOmUzd8syaTuqfgGvFcn6DzA5Cmb+Vby1ST+U3Y=</pin>
+            <pin digest="SHA-256">ppiiCCS+BOR6GjPE+kiHMb6SAR8jox6QDiyibJwqz84=</pin>
+            <pin digest="SHA-256">LoMHBotttiDko50Gi13uXW71eIy7LAttI+rYT8wXF4w=</pin>
+            <pin digest="SHA-256">nWN7PSep5XDQdge5zK24CnCRXHr3KvzhKEGxsdqCX9E=</pin>
+            <pin digest="SHA-256">UaqofZhLVZrGnpKfiIoCLYMuCJ/026CkErUQG8pLx5k=</pin>
+        </pin-set>
+    </domain-config>
 </network-security-config>


### PR DESCRIPTION
https://developer.android.com/privacy-and-security/security-config
Network security config allows to pin certs for specific domains (see Pin certificates section on page above), so MITM harder to perform successfully. 

It is possible to make pinning to CA certificates (and this is exactly what I had done in PR changes):
> Certificate pinning is done by providing a set of certificates by hash of the public key (SubjectPublicKeyInfo of the X.509 certificate). A certificate chain is then valid only if the certificate chain contains at least one of the pinned public keys.

But after expiration date pinning is not performed (this is one of the reasons to keep updates enabled for many apps):
> Additionally, it is possible to set an expiration time for pins after which pinning is not performed. This helps prevent connectivity issues in apps which have not been updated. However, setting an expiration time on pins may enable attackers to bypass your pinned certificates

Cert pinning was added for next domains: f-droid.org, guardianproject.info, apt.izzysoft.de, app.futo.org, molly.im, app.simplex.chat, briarproject.org, microg.org, cdn.kde.org . There are plans to add pinning for some others (IronFox and Brave repos)

Changes are tested. This is how I tested them:
- 2 different devices, 2 different networks
- apllication works with added certificate pinning - connection to repositories hosted on domains above work fine, as well as obtaining from them
- apllication works with **incorrectly** added certificate pinning - connection to repositories hosted on domains above does not work, so this is confirms the fact the changes have effect on app functionality

It is possible to obtain certificate pubkey hashes in two ways I know:
- using https://www.ssllabs.com/ssltest (after end of test "Pin SHA256" value for eachc cert in chain is displayed, just take CAs intermediate one and that's it)
- using bash and openssl:
```
openssl x509 -in /path/to/intermidiate-ca-cert.pem -pubkey -noout | \
openssl pkey -pubin -outform DER | \
openssl dgst -sha256 -binary | \
openssl base64
```

The faster these changes are in the release version the better for users :)