### PR TITLE
disallow cleartext traffic for release builds (allow only for debug)

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -48,11 +48,13 @@ android {
         debug {
             applicationIdSuffix = ".debug"
             resValue("string", "application_name", "Droid-ify-Debug")
+            resValue("string", "cleartext_allowed", "true")
         }
         release {
             isMinifyEnabled = true
             isShrinkResources = true
             resValue("string", "application_name", "Droid-ify")
+            resValue("string", "cleartext_allowed", "false")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard.pro",
@@ -62,6 +64,7 @@ android {
             initWith(getByName("debug"))
             applicationIdSuffix = ".alpha"
             resValue("string", "application_name", "Droid-ify Alpha")
+            resValue("string", "cleartext_allowed", "false")
             proguardFiles(
                 getDefaultProguardFile("proguard-android-optimize.txt"),
                 "proguard.pro",

--- a/app/src/main/res/xml/network_security_config.xml
+++ b/app/src/main/res/xml/network_security_config.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <network-security-config>
-    <base-config cleartextTrafficPermitted="true">
+    <base-config cleartextTrafficPermitted="@string/cleartext_allowed">
         <trust-anchors>
             <!-- Trust preinstalled CAs -->
             <certificates src="system" />


### PR DESCRIPTION
possibility for cleartext traffic is bad for end-user, so better disable it. allowing cleartext traffic was introduced in #68 and this PR is part of planned harm-reduction.