### PR TITLE
perf: room: create index for recommended columns

### DIFF
--- a/app/schemas/com.looker.droidify.data.local.DroidifyDatabase/2.json
+++ b/app/schemas/com.looker.droidify.data.local.DroidifyDatabase/2.json
@@ -2,7 +2,7 @@
   "formatVersion": 1,
   "database": {
     "version": 2,
-    "identityHash": "7e79a80c511686b3c0c965ef14dbc7f1",
+    "identityHash": "696d6d9cb2b65906dc4135b5e0f328e4",
     "entities": [
       {
         "tableName": "anti_feature",
@@ -82,6 +82,17 @@
             "versionCode"
           ]
         },
+        "indices": [
+          {
+            "name": "index_anti_features_app_relation_appId",
+            "unique": false,
+            "columnNames": [
+              "appId"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_anti_features_app_relation_appId` ON `${TABLE_NAME}` (`appId`)"
+          }
+        ],
         "foreignKeys": [
           {
             "table": "app",
@@ -447,6 +458,17 @@
             "defaultName"
           ]
         },
+        "indices": [
+          {
+            "name": "index_category_app_relation_defaultName",
+            "unique": false,
+            "columnNames": [
+              "defaultName"
+            ],
+            "orders": [],
+            "createSql": "CREATE INDEX IF NOT EXISTS `index_category_app_relation_defaultName` ON `${TABLE_NAME}` (`defaultName`)"
+          }
+        ],
         "foreignKeys": [
           {
             "table": "app",
@@ -1153,7 +1175,7 @@
     ],
     "setupQueries": [
       "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
-      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7e79a80c511686b3c0c965ef14dbc7f1')"
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '696d6d9cb2b65906dc4135b5e0f328e4')"
     ]
   }
 }

--- a/app/src/main/kotlin/com/looker/droidify/data/local/model/AntiFeatureEntity.kt
+++ b/app/src/main/kotlin/com/looker/droidify/data/local/model/AntiFeatureEntity.kt
@@ -52,6 +52,7 @@ data class AntiFeatureRepoRelation(
 data class AntiFeatureAppRelation(
     val tag: Tag,
     val reason: AntiFeatureReason,
+    @ColumnInfo(index = true)
     val appId: Int,
     val versionCode: Long,
 )

--- a/app/src/main/kotlin/com/looker/droidify/data/local/model/CategoryEntity.kt
+++ b/app/src/main/kotlin/com/looker/droidify/data/local/model/CategoryEntity.kt
@@ -53,6 +53,7 @@ data class CategoryRepoRelation(
 data class CategoryAppRelation(
     @ColumnInfo("id")
     val appId: Int,
+    @ColumnInfo(index = true)
     val defaultName: DefaultName,
 )
 


### PR DESCRIPTION
While this may add additional overhead when inserting/deleting/updating there is an improvement while querying, which is more important for responsiveness.

Apply suggestions pointed out by ksp:

```
w: [ksp] app/src/main/kotlin/com/looker/droidify/data/local/model/AntiFeatureEntity.kt:52: appId column references a foreign key but it is not part of an index. This may trigger full table scans whenever parent table is modified so you are highly advised to create an index that covers this column.

w: [ksp] app/src/main/kotlin/com/looker/droidify/data/local/model/CategoryEntity.kt:56: The column defaultName in the junction entity com.looker.droidify.`data`.local.model.CategoryAppRelation is being used to resolve a relationship but it is not covered by any index. This might cause a full table scan when resolving the relationship, it is highly advised to create an index that covers this column.
```