### PR TITLE
feat: play video from app details screen within app

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -161,6 +161,8 @@ dependencies {
     implementation(libs.bundles.compose)
     debugImplementation(libs.bundles.compose.debug)
 
+    implementation(libs.bundles.media3)
+
     testImplementation(platform(libs.junit.bom))
     testImplementation(libs.bundles.test.unit)
     testImplementation(libs.room.test)

--- a/app/src/main/kotlin/com/looker/droidify/di/FileModule.kt
+++ b/app/src/main/kotlin/com/looker/droidify/di/FileModule.kt
@@ -1,0 +1,27 @@
+package com.looker.droidify.di
+
+import android.content.Context
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import java.io.File
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class CacheDirectory
+
+@Module
+@InstallIn(SingletonComponent::class)
+object FileModule {
+
+    @Singleton
+    @Provides
+    @CacheDirectory
+    fun provideCacheDirectory(
+        @ApplicationContext context: Context,
+    ): File = context.cacheDir
+}

--- a/app/src/main/kotlin/com/looker/droidify/di/MediaModule.kt
+++ b/app/src/main/kotlin/com/looker/droidify/di/MediaModule.kt
@@ -1,0 +1,83 @@
+package com.looker.droidify.di
+
+import android.content.Context
+import androidx.annotation.OptIn
+import androidx.media3.common.util.UnstableApi
+import androidx.media3.database.DatabaseProvider
+import androidx.media3.database.StandaloneDatabaseProvider
+import androidx.media3.datasource.DataSource
+import androidx.media3.datasource.DefaultDataSource
+import androidx.media3.datasource.cache.Cache
+import androidx.media3.datasource.cache.CacheDataSource
+import androidx.media3.datasource.cache.LeastRecentlyUsedCacheEvictor
+import androidx.media3.datasource.cache.SimpleCache
+import androidx.media3.datasource.okhttp.OkHttpDataSource
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import okhttp3.OkHttpClient
+import java.io.File
+import javax.inject.Qualifier
+import javax.inject.Singleton
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class DefaultDataSourceFactory
+
+@Qualifier
+@Retention(AnnotationRetention.BINARY)
+annotation class CacheDataSourceFactory
+
+@Module
+@InstallIn(SingletonComponent::class)
+@OptIn(UnstableApi::class)
+object MediaModule {
+
+    @Singleton
+    @Provides
+    fun provideDatabaseProvider(
+        @ApplicationContext context: Context,
+    ): DatabaseProvider = StandaloneDatabaseProvider(context)
+
+    @Singleton
+    @Provides
+    fun provideSimpleCache(
+        databaseProvider: DatabaseProvider,
+        @CacheDirectory cacheDirectory: File,
+    ): Cache = SimpleCache(
+        cacheDirectory,
+        LeastRecentlyUsedCacheEvictor(50 * 1024 * 1024 /* 50 MB */),
+        databaseProvider,
+    )
+
+    @Singleton
+    @Provides
+    fun provideOkHttpClient(): OkHttpClient = OkHttpClient.Builder()
+        .build()
+
+    @Singleton
+    @Provides
+    fun provideOkHttpDataSourceFactory(
+        okHttpClient: OkHttpClient,
+    ): OkHttpDataSource.Factory = OkHttpDataSource.Factory(okHttpClient)
+
+    @Singleton
+    @Provides
+    @DefaultDataSourceFactory
+    fun provideDefaultDataSourceFactory(
+        @ApplicationContext context: Context,
+        okHttpDataSourceFactory: OkHttpDataSource.Factory,
+    ): DataSource.Factory = DefaultDataSource.Factory(context, okHttpDataSourceFactory)
+
+    @Singleton
+    @Provides
+    @CacheDataSourceFactory
+    fun provideCacheDataSourceFactory(
+        cache: Cache,
+        @DefaultDataSourceFactory dataSourceFactory: DataSource.Factory,
+    ): DataSource.Factory = CacheDataSource.Factory()
+        .setCache(cache)
+        .setUpstreamDataSourceFactory(dataSourceFactory)
+}

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -106,6 +106,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
         fun onReleaseClick(release: Release)
         fun onRequestAddRepository(address: String)
         fun onUriClick(uri: Uri, shouldConfirm: Boolean): Boolean
+        fun onVideoClick(videoUri: Uri)
     }
 
     enum class Action(@StringRes val titleResId: Int, @DrawableRes val iconResId: Int) {
@@ -1430,7 +1431,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                     setPadding(8.dp, 8.dp, 8.dp, 8.dp)
                     layoutManager =
                         LinearLayoutManager(context, LinearLayoutManager.HORIZONTAL, false)
-                    adapter = ScreenshotsAdapter(callbacks::onScreenshotClick).apply {
+                    adapter = ScreenshotsAdapter(
+                        onClick = callbacks::onScreenshotClick,
+                        onVideoClick = callbacks::onVideoClick,
+                    ).apply {
                         setScreenshots(item.repository, item.packageName, item.screenshots)
                     }
                 }

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
@@ -557,6 +557,10 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
         }
     }
 
+    override fun onVideoClick(videoUri: Uri) {
+        VideoPlayerDialog.showVideoFromUri(parentFragmentManager, videoUri)
+    }
+
     class LaunchDialog() : DialogFragment() {
         companion object {
             private const val EXTRA_NAMES = "names"

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/ScreenshotsAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/ScreenshotsAdapter.kt
@@ -2,9 +2,11 @@ package com.looker.droidify.ui.appDetail
 
 import android.content.Context
 import android.graphics.drawable.Drawable
+import android.net.Uri
 import android.view.Gravity
 import android.view.ViewGroup
 import android.widget.FrameLayout
+import androidx.core.net.toUri
 import androidx.recyclerview.widget.RecyclerView
 import coil3.asImage
 import coil3.dispose
@@ -22,13 +24,15 @@ import com.looker.droidify.utility.common.extension.camera
 import com.looker.droidify.utility.common.extension.dp
 import com.looker.droidify.utility.common.extension.getColorFromAttr
 import com.looker.droidify.utility.common.extension.layoutInflater
-import com.looker.droidify.utility.common.extension.openLink
 import com.looker.droidify.utility.common.extension.selectableBackground
 import com.looker.droidify.widget.StableRecyclerAdapter
 import com.google.android.material.R as MaterialR
 import com.looker.droidify.R.dimen as dimenRes
 
-class ScreenshotsAdapter(private val onClick: (position: Int) -> Unit) :
+class ScreenshotsAdapter(
+    private val onClick: (position: Int) -> Unit,
+    private val onVideoClick: (videoUri: Uri) -> Unit,
+) :
     StableRecyclerAdapter<ScreenshotsAdapter.ViewType, RecyclerView.ViewHolder>() {
     enum class ViewType { SCREENSHOT, VIDEO }
 
@@ -47,7 +51,7 @@ class ScreenshotsAdapter(private val onClick: (position: Int) -> Unit) :
                 )
                 setOnClickListener {
                     val item = items[absoluteAdapterPosition] as Item.VideoItem
-                    it.context?.openLink(item.videoUrl)
+                    onVideoClick(item.videoUrl.toUri())
                 }
             }
         }

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/VideoPlayerDialog.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/VideoPlayerDialog.kt
@@ -1,0 +1,114 @@
+package com.looker.droidify.ui.appDetail
+
+import android.net.Uri
+import android.os.Build
+import android.os.Bundle
+import android.util.Log
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import androidx.fragment.app.DialogFragment
+import androidx.fragment.app.FragmentManager
+import androidx.media3.common.MediaItem
+import androidx.media3.datasource.DataSource
+import androidx.media3.exoplayer.ExoPlayer
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory
+import com.looker.droidify.R
+import com.looker.droidify.databinding.VideoPlayerDialogBinding
+import com.looker.droidify.di.CacheDataSourceFactory
+import dagger.hilt.android.AndroidEntryPoint
+import javax.inject.Inject
+
+@AndroidEntryPoint
+class VideoPlayerDialog : DialogFragment() {
+
+    private var _binding: VideoPlayerDialogBinding? = null
+    private val binding get() = _binding!!
+
+    @Inject
+    @CacheDataSourceFactory
+    lateinit var dataSourceFactory: DataSource.Factory
+
+    private val player: ExoPlayer by lazy {
+        ExoPlayer.Builder(requireContext())
+            .setMediaSourceFactory(
+                DefaultMediaSourceFactory(requireContext()).setDataSourceFactory(dataSourceFactory),
+            )
+            .build()
+    }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setStyle(STYLE_NORMAL, R.style.Theme_Dialog_Fullscreen)
+    }
+
+    override fun onCreateView(inflater: LayoutInflater, container: ViewGroup?, savedInstanceState: Bundle?): View {
+        _binding = VideoPlayerDialogBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onDestroyView() {
+        player.release()
+        _binding = null
+        super.onDestroyView()
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+        binding.closePlayer.setOnClickListener { dismiss() }
+
+        // Get the video uri from the arguments and if none exists, dismiss the dialog without any playback.
+        val videoUri: Uri? = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            arguments?.getParcelable(ARG_VIDEO_URI, Uri::class.java)
+        } else {
+            arguments?.getParcelable(ARG_VIDEO_URI)
+        }
+        if (videoUri == null) {
+            dismiss()
+            return
+        }
+
+        binding.playerView.player = player
+
+        val mediaItem = MediaItem.fromUri(videoUri)
+        player.setMediaItem(mediaItem)
+        player.prepare()
+
+        // Restore playback state if we got recreated.
+        val currentPosition = savedInstanceState?.getLong(ARG_VIDEO_PLAYBACK_MS)
+        if (currentPosition != null) {
+            player.seekTo(currentPosition)
+        }
+
+        // Start the video as soon as the player is ready.
+        player.playWhenReady = true
+    }
+
+    override fun onSaveInstanceState(outState: Bundle) {
+        super.onSaveInstanceState(outState)
+
+        try {
+            outState.putLong(ARG_VIDEO_PLAYBACK_MS, player.currentPosition)
+        } catch (exc: Exception) {
+            Log.e(TAG, "Could not save current position", exc)
+        }
+    }
+
+    companion object {
+        private const val TAG = "VideoPlayerDialog"
+
+        private const val ARG_VIDEO_URI = "video_uri"
+        private const val ARG_VIDEO_PLAYBACK_MS = "video_playback_ms"
+
+        fun showVideoFromUri(fragmentManager: FragmentManager, videoUri: Uri) {
+            val videoPlayerDialog = VideoPlayerDialog().apply {
+                arguments = Bundle().apply {
+                    putParcelable(ARG_VIDEO_URI, videoUri)
+                }
+            }
+            videoPlayerDialog.show(fragmentManager, TAG)
+        }
+
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/utility/common/extension/Context.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/common/extension/Context.kt
@@ -5,7 +5,6 @@ import android.app.job.JobScheduler
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
-import android.content.Intent
 import android.content.res.ColorStateList
 import android.graphics.drawable.Drawable
 import android.os.PowerManager
@@ -15,7 +14,6 @@ import androidx.annotation.DrawableRes
 import androidx.appcompat.content.res.AppCompatResources
 import androidx.core.content.ContextCompat
 import androidx.core.content.getSystemService
-import androidx.core.net.toUri
 import com.looker.droidify.R
 
 inline val Context.clipboardManager: ClipboardManager?
@@ -35,13 +33,6 @@ inline val Context.powerManager: PowerManager?
 
 fun Context.copyToClipboard(clip: String) {
     clipboardManager?.setPrimaryClip(ClipData.newPlainText(null, clip))
-}
-
-fun Context.openLink(url: String) {
-    val intent = intent(Intent.ACTION_VIEW) {
-        setData(url.toUri())
-    }
-    startActivity(intent)
 }
 
 val Context.corneredBackground: Drawable

--- a/app/src/main/res/layout/video_player_dialog.xml
+++ b/app/src/main/res/layout/video_player_dialog.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:keepScreenOn="true">
+
+    <androidx.media3.ui.PlayerView
+        android:id="@+id/player_view"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        app:show_buffering="when_playing"
+        app:show_next_button="false"
+        app:show_previous_button="false"
+        app:time_bar_scrubbing_enabled="true" />
+
+    <ImageButton
+        android:id="@+id/close_player"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="4dp"
+        android:background="#424242"
+        android:padding="4dp"
+        android:src="@drawable/ic_cancel"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:tint="@android:color/white" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -242,4 +242,10 @@
         <item name="cornerFamily">rounded</item>
         <item name="cornerSize">50%</item>
     </style>
+
+    <style name="Theme.Dialog.Fullscreen" parent="Theme.Main.Amoled">
+        <item name="android:statusBarColor">@android:color/black</item>
+        <item name="android:windowFullscreen">false</item>
+        <item name="android:windowIsFloating">false</item>
+    </style>
 </resources>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -36,6 +36,7 @@ arch-core-testing = "2.2.0"
 compose-bom = "2025.12.01"
 compose-navigation = "2.9.6"
 vico = "2.4.1"
+media3 = "1.9.0"
 
 [libraries]
 desugaring = { group = "com.android.tools", name = "desugar_jdk_libs", version.ref = "desugaring" }
@@ -111,6 +112,11 @@ compose-navigation = { group = "androidx.navigation", name = "navigation-compose
 compose-hilt-navigation = { group = "androidx.hilt", name = "hilt-navigation-compose", version.ref = "hiltExt" }
 compose-lifecycle-viewmodel = { group = "androidx.lifecycle", name = "lifecycle-viewmodel-compose", version.ref = "lifecycle" }
 
+# Media3 dependencies
+media3-datasource-okhttp = { group = "androidx.media3", name = "media3-datasource-okhttp", version.ref = "media3" }
+media3-exoplayer = { group = "androidx.media3", name = "media3-exoplayer", version.ref = "media3" }
+media3-ui = { group = "androidx.media3", name = "media3-ui", version.ref = "media3" }
+
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hilt" }
@@ -131,3 +137,4 @@ test-unit = ["junit-jupiter", "ktor-mock", "coroutines-test", "kotlin-test"]
 test-android = ["test-runner", "test-rules", "test-ext", "coroutines-test", "kotlin-test"]
 compose = ["compose-ui", "compose-ui-graphics", "compose-ui-tooling-preview", "compose-material3", "compose-material-icons", "compose-activity", "compose-navigation", "compose-hilt-navigation", "compose-lifecycle-viewmodel"]
 compose-debug = ["compose-ui-tooling", "compose-ui-test-manifest"]
+media3 = ["media3-datasource-okhttp", "media3-exoplayer", "media3-ui"]


### PR DESCRIPTION
Instead of opening the video link in an external browser, use ExoPlayer to play it within the app.

When pressing on the video, a new fullscreen dialog will open, which contains the ExoPlayer player view.

Issue: https://github.com/Droid-ify/client/issues/1172