### PR TITLE
feat: add progress indicator to app list during updates

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/DownloadStatus.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/DownloadStatus.kt
@@ -1,0 +1,12 @@
+package com.looker.droidify.ui
+
+import com.looker.droidify.network.DataSize
+
+sealed interface DownloadStatus {
+    data object Idle : DownloadStatus
+    data object Pending : DownloadStatus
+    data object Connecting : DownloadStatus
+    data class Downloading(val read: DataSize, val total: DataSize?) : DownloadStatus
+    data object PendingInstall : DownloadStatus
+    data object Installing : DownloadStatus
+}

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -54,6 +54,7 @@ import com.looker.droidify.model.Repository
 import com.looker.droidify.model.findSuggested
 import com.looker.droidify.network.DataSize
 import com.looker.droidify.network.percentBy
+import com.looker.droidify.ui.DownloadStatus
 import com.looker.droidify.utility.PackageItemResolver
 import com.looker.droidify.utility.common.extension.authentication
 import com.looker.droidify.utility.common.extension.copyToClipboard
@@ -117,15 +118,6 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
         CANCEL(stringRes.cancel, drawableRes.ic_cancel),
         SHARE(stringRes.share, drawableRes.ic_share),
         SOURCE(stringRes.source_code, drawableRes.ic_source_code),
-    }
-
-    sealed interface Status {
-        data object Idle : Status
-        data object Pending : Status
-        data object Connecting : Status
-        data class Downloading(val read: DataSize, val total: DataSize?) : Status
-        data object PendingInstall : Status
-        data object Installing : Status
     }
 
     enum class ViewType {
@@ -1071,7 +1063,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
             field = value
         }
 
-    var status: Status = Status.Idle
+    var status: DownloadStatus = DownloadStatus.Idle
         set(value) {
             if (field != value) {
                 val index = items.indexOf(Item.DownloadStatusItem)
@@ -1336,22 +1328,22 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                 holder as DownloadStatusViewHolder
                 item as Item.DownloadStatusItem
                 val status = status
-                holder.itemView.isVisible = status != Status.Idle
-                holder.statusText.isVisible = status != Status.Idle
-                holder.progress.isVisible = status != Status.Idle
-                if (status != Status.Idle) {
+                holder.itemView.isVisible = status != DownloadStatus.Idle
+                holder.statusText.isVisible = status != DownloadStatus.Idle
+                holder.progress.isVisible = status != DownloadStatus.Idle
+                if (status != DownloadStatus.Idle) {
                     when (status) {
-                        is Status.Pending -> {
+                        is DownloadStatus.Pending -> {
                             holder.statusText.setText(stringRes.waiting_to_start_download)
                             holder.progress.isIndeterminate = true
                         }
 
-                        is Status.Connecting -> {
+                        is DownloadStatus.Connecting -> {
                             holder.statusText.setText(stringRes.connecting)
                             holder.progress.isIndeterminate = true
                         }
 
-                        is Status.Downloading -> {
+                        is DownloadStatus.Downloading -> {
                             holder.statusText.text = context.getString(
                                 stringRes.downloading_FORMAT,
                                 if (status.total == null) {
@@ -1369,17 +1361,17 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                             }
                         }
 
-                        Status.Installing -> {
+                        DownloadStatus.Installing -> {
                             holder.statusText.setText(stringRes.installing)
                             holder.progress.isIndeterminate = true
                         }
 
-                        Status.PendingInstall -> {
+                        DownloadStatus.PendingInstall -> {
                             holder.statusText.setText(stringRes.waiting_to_start_installation)
                             holder.progress.isIndeterminate = true
                         }
 
-                        Status.Idle -> {}
+                        DownloadStatus.Idle -> {}
                     }
                 }
             }
@@ -1760,7 +1752,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                         minSdkVersion
                     )
                 }
-                val enabled = status == Status.Idle
+                val enabled = status == DownloadStatus.Idle
                 holder.statefulViews.forEach { it.isEnabled = enabled }
             }
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
@@ -35,6 +35,7 @@ import com.looker.droidify.model.Repository
 import com.looker.droidify.model.findSuggested
 import com.looker.droidify.service.Connection
 import com.looker.droidify.service.DownloadService
+import com.looker.droidify.ui.DownloadStatus
 import com.looker.droidify.ui.Message
 import com.looker.droidify.ui.MessageDialog
 import com.looker.droidify.ui.ScreenFragment
@@ -306,9 +307,9 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
     private fun updateInstallState(installerState: InstallState?) {
         val status = when (installerState) {
-            InstallState.Pending -> AppDetailAdapter.Status.PendingInstall
-            InstallState.Installing -> AppDetailAdapter.Status.Installing
-            else -> AppDetailAdapter.Status.Idle
+            InstallState.Pending -> DownloadStatus.PendingInstall
+            InstallState.Installing -> DownloadStatus.Installing
+            else -> DownloadStatus.Idle
         }
         (recyclerView?.adapter as? AppDetailAdapter)?.status = status
         installing = installerState
@@ -322,21 +323,21 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
         val isCompleted = state isComplete packageName
         val isActive = isPending || isDownloading
         if (isPending) {
-            detailAdapter?.status = AppDetailAdapter.Status.Pending
+            detailAdapter?.status = DownloadStatus.Pending
         }
         if (isDownloading) {
             detailAdapter?.status = when (state.currentItem) {
-                is DownloadService.State.Connecting -> AppDetailAdapter.Status.Connecting
-                is DownloadService.State.Downloading -> AppDetailAdapter.Status.Downloading(
+                is DownloadService.State.Connecting -> DownloadStatus.Connecting
+                is DownloadService.State.Downloading -> DownloadStatus.Downloading(
                     state.currentItem.read,
                     state.currentItem.total,
                 )
 
-                else -> AppDetailAdapter.Status.Idle
+                else -> DownloadStatus.Idle
             }
         }
         if (isCompleted) {
-            detailAdapter?.status = AppDetailAdapter.Status.Idle
+            detailAdapter?.status = DownloadStatus.Idle
         }
         if (this.downloading != isActive) {
             this.downloading = isActive

--- a/app/src/main/kotlin/com/looker/droidify/ui/appList/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appList/AppListViewModel.kt
@@ -7,9 +7,12 @@ import com.looker.droidify.database.CursorOwner.Request.Available
 import com.looker.droidify.database.CursorOwner.Request.Installed
 import com.looker.droidify.database.CursorOwner.Request.Updates
 import com.looker.droidify.database.Database
+import com.looker.droidify.data.model.PackageName
 import com.looker.droidify.datastore.SettingsRepository
 import com.looker.droidify.datastore.get
 import com.looker.droidify.datastore.model.SortOrder
+import com.looker.droidify.installer.InstallManager
+import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.model.ProductItem
 import com.looker.droidify.model.ProductItem.Section.All
 import com.looker.droidify.service.Connection
@@ -18,6 +21,7 @@ import com.looker.droidify.utility.common.extension.asStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.combine
 import kotlinx.coroutines.flow.flatMapLatest
 import kotlinx.coroutines.flow.map
@@ -28,7 +32,10 @@ import javax.inject.Inject
 class AppListViewModel
 @Inject constructor(
     settingsRepository: SettingsRepository,
+    installManager: InstallManager,
 ) : ViewModel() {
+
+    val installStates: StateFlow<Map<PackageName, InstallState>> = installManager.state
 
     private val skipSignatureStream = settingsRepository
         .get { ignoreSignature }

--- a/app/src/main/res/layout/product_item.xml
+++ b/app/src/main/res/layout/product_item.xml
@@ -3,66 +3,82 @@
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="72dp"
+    android:layout_height="wrap_content"
     android:layout_marginHorizontal="@dimen/shape_margin_medium">
 
     <LinearLayout
         android:layout_width="match_parent"
-        android:layout_height="match_parent"
-        android:gravity="center_vertical"
-        android:orientation="horizontal"
-        android:paddingHorizontal="10dp">
-
-        <com.google.android.material.imageview.ShapeableImageView
-            android:id="@+id/icon"
-            android:layout_width="56dp"
-            android:layout_height="56dp"
-            app:shapeAppearanceOverlay="@style/Shape.Small"
-            tools:ignore="ContentDescription" />
+        android:layout_height="wrap_content"
+        android:orientation="vertical">
 
         <LinearLayout
             android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_gravity="center_vertical"
-            android:layout_marginStart="14dp"
-            android:orientation="vertical">
+            android:layout_height="72dp"
+            android:gravity="center_vertical"
+            android:orientation="horizontal"
+            android:paddingHorizontal="10dp">
+
+            <com.google.android.material.imageview.ShapeableImageView
+                android:id="@+id/icon"
+                android:layout_width="56dp"
+                android:layout_height="56dp"
+                app:shapeAppearanceOverlay="@style/Shape.Small"
+                tools:ignore="ContentDescription" />
 
             <LinearLayout
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:gravity="center_vertical"
-                android:orientation="horizontal">
+                android:layout_gravity="center_vertical"
+                android:layout_marginStart="14dp"
+                android:orientation="vertical">
 
-                <FrameLayout
-                    android:layout_width="0dp"
+                <LinearLayout
+                    android:layout_width="match_parent"
                     android:layout_height="wrap_content"
-                    android:layout_weight="1">
+                    android:gravity="center_vertical"
+                    android:orientation="horizontal">
+
+                    <FrameLayout
+                        android:layout_width="0dp"
+                        android:layout_height="wrap_content"
+                        android:layout_weight="1">
+
+                        <TextView
+                            android:id="@+id/name"
+                            android:layout_width="wrap_content"
+                            android:layout_height="wrap_content"
+                            android:singleLine="true"
+                            android:textAppearance="?textAppearanceBody1" />
+                    </FrameLayout>
 
                     <TextView
-                        android:id="@+id/name"
+                        android:id="@+id/status"
                         android:layout_width="wrap_content"
                         android:layout_height="wrap_content"
+                        android:maxWidth="80dp"
                         android:singleLine="true"
-                        android:textAppearance="?textAppearanceBody1" />
-                </FrameLayout>
+                        android:textAppearance="?textAppearanceLabelMedium" />
+
+                </LinearLayout>
 
                 <TextView
-                    android:id="@+id/status"
+                    android:id="@+id/summary"
                     android:layout_width="wrap_content"
                     android:layout_height="wrap_content"
-                    android:maxWidth="80dp"
                     android:singleLine="true"
-                    android:textAppearance="?textAppearanceLabelMedium" />
-
+                    android:textAppearance="?textAppearanceBody2"
+                    android:textColor="?attr/colorOutline" />
             </LinearLayout>
-
-            <TextView
-                android:id="@+id/summary"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:singleLine="true"
-                android:textAppearance="?textAppearanceBody2"
-                android:textColor="?attr/colorOutline" />
         </LinearLayout>
+
+        <com.google.android.material.progressindicator.LinearProgressIndicator
+            android:id="@+id/progress"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:indeterminate="true"
+            android:visibility="gone"
+            app:trackCornerRadius="0dp"
+            app:trackThickness="4dp" />
+
     </LinearLayout>
 </com.google.android.material.card.MaterialCardView>


### PR DESCRIPTION
Show download and install progress for each app in the updates tab when using "Update all". Extracts DownloadStatus to a shared sealed interface used by both AppListAdapter and AppDetailAdapter.

Related issues:
- #341
- #1156