### PR TITLE
fix: Prevent settings toggles and text from animating on page open

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
@@ -518,7 +518,7 @@ class SettingsFragment : Fragment() {
     ) {
         title.text = titleText
         viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
                 setting.collect {
                     with(root.context) {
                         content.text = map(it)
@@ -541,10 +541,15 @@ class SettingsFragment : Fragment() {
         root.setOnClickListener {
             checked.isChecked = !checked.isChecked
         }
+        var skipAnimation = true
         viewLifecycleOwner.lifecycleScope.launch {
-            repeatOnLifecycle(Lifecycle.State.RESUMED) {
+            repeatOnLifecycle(Lifecycle.State.STARTED) {
                 setting.collect {
                     checked.isChecked = it
+                    if (skipAnimation) {
+                        checked.jumpDrawablesToCurrentState()
+                        skipAnimation = false
+                    }
                 }
             }
         }


### PR DESCRIPTION
Fix settings toggles animating on page open

  - Change lifecycle state from RESUMED to STARTED for earlier value collection
  - Add jumpDrawablesToCurrentState() to skip switch animation on initial load
  - Fixes text values (Languages, Theme, etc.) appearing with delay

  Fixes #1197