### PR TITLE
fix: Set correct installer package name for Shizuku

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
@@ -21,6 +21,7 @@ class RootInstaller(private val context: Context) : Installer {
         val installCommand = INSTALL_COMMAND.format(
             releaseFile.absolutePath,
             currentUser(),
+            context.packageName,
             releaseFile.length(),
         )
         Shell.cmd(installCommand).submit { shellResult ->
@@ -39,7 +40,7 @@ class RootInstaller(private val context: Context) : Installer {
 
 }
 
-private const val INSTALL_COMMAND = "cat %s | pm install --user %s -t -r -S %s"
+private const val INSTALL_COMMAND = "cat %s | pm install --user %s -i %s -t -r -S %s"
 private const val DELETE_COMMAND = "%s rm %s"
 
 /** Returns the path of either toybox or busybox, or empty string if not found. */

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
@@ -25,7 +25,6 @@ class ShizukuInstaller(private val context: Context) : Installer {
     ): InstallState = suspendCancellableCoroutine { cont ->
         var sessionId: String? = null
         val file = Cache.getReleaseFile(context, installItem.installFileName)
-        val packageName = installItem.packageName.name
         try {
             val fileSize = file.length()
             if (fileSize == 0L) {
@@ -33,12 +32,13 @@ class ShizukuInstaller(private val context: Context) : Installer {
                 error("File is not valid: Size ${file.size}")
             }
             if (cont.isCompleted) return@suspendCancellableCoroutine
+            val installerPackage = context.packageName
             file.inputStream().use {
                 val createCommand =
                     if (SdkCheck.isNougat) {
-                        "pm install-create --user current -i $packageName -S $fileSize"
+                        "pm install-create --user current -i $installerPackage -S $fileSize"
                     } else {
-                        "pm install-create -i $packageName -S $fileSize"
+                        "pm install-create -i $installerPackage -S $fileSize"
                     }
                 val createResult = exec(createCommand)
                 sessionId = SESSION_ID_REGEX.find(createResult.out)?.value


### PR DESCRIPTION
Apps installed via Shizuku and Root installers were not being marked as "App installed from (D)roid-ify" in system settings because the wrong package name was passed to the -i flag.

ShizukuInstaller was using the installed app's package name instead of Droid-ify's package name. RootInstaller was missing the -i flag entirely.

Now both installers use context.packageName to correctly identify Droid-ify as the installer, so `pm list packages -i` returns `installer=com.looker.droidify`.

Fixes #1044