### PR TITLE
Fix: Favourite apps version coloring

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/favourites/FavouriteFragmentAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/favourites/FavouriteFragmentAdapter.kt
@@ -6,7 +6,7 @@ import androidx.core.view.isVisible
 import androidx.recyclerview.widget.RecyclerView
 import coil3.load
 import com.looker.droidify.databinding.ProductItemBinding
-import com.looker.droidify.model.Product
+import com.looker.droidify.model.ProductItem
 import com.looker.droidify.model.Repository
 import com.looker.droidify.utility.common.extension.authentication
 import com.looker.droidify.utility.common.extension.corneredBackground
@@ -19,14 +19,14 @@ class FavouriteFragmentAdapter(
     private val onProductClick: (String) -> Unit
 ) : RecyclerView.Adapter<FavouriteFragmentAdapter.ViewHolder>() {
 
-    inner class ViewHolder(binding: ProductItemBinding) : RecyclerView.ViewHolder(binding.root) {
+    class ViewHolder(binding: ProductItemBinding) : RecyclerView.ViewHolder(binding.root) {
         val icon = binding.icon
         val name = binding.name
         val summary = binding.summary
         val version = binding.status
     }
 
-    var apps: List<List<Product>> = emptyList()
+    var apps: List<ProductItem> = emptyList()
         set(value) {
             field = value
             notifyDataSetChanged()
@@ -47,8 +47,8 @@ class FavouriteFragmentAdapter(
             )
         ).apply {
             itemView.setOnClickListener {
-                if (apps.isNotEmpty() && apps[absoluteAdapterPosition].firstOrNull() != null) {
-                    onProductClick(apps[absoluteAdapterPosition].first().packageName)
+                if (apps.isNotEmpty()) {
+                    onProductClick(apps[absoluteAdapterPosition].packageName)
                 }
             }
         }
@@ -56,20 +56,25 @@ class FavouriteFragmentAdapter(
     override fun getItemCount(): Int = apps.size
 
     override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-        val item = apps[position].first().item()
+        val item = apps[position]
+        val context = holder.itemView.context
+        val installedVersion = item.installedVersion.nullIfEmpty()
+
         val repository: Repository? = repositories[item.repositoryId]
         holder.name.text = item.name
         holder.summary.isVisible = item.summary.isNotEmpty()
         holder.summary.text = item.summary
+
         if (repository != null) {
             val iconUrl = item.icon(holder.icon, repository)
             holder.icon.load(iconUrl) {
                 authentication(repository.authentication)
             }
         }
+
         holder.version.apply {
-            text = item.installedVersion.nullIfEmpty() ?: item.version
-            val isInstalled = item.installedVersion.nullIfEmpty() != null
+            text = installedVersion ?: item.version
+            val isInstalled = installedVersion != null
             when {
                 item.canUpdate -> {
                     backgroundTintList =

--- a/app/src/main/kotlin/com/looker/droidify/ui/favourites/FavouritesViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/favourites/FavouritesViewModel.kt
@@ -4,7 +4,7 @@ import androidx.lifecycle.ViewModel
 import com.looker.droidify.database.Database
 import com.looker.droidify.datastore.SettingsRepository
 import com.looker.droidify.datastore.get
-import com.looker.droidify.model.Product
+import com.looker.droidify.model.ProductItem
 import com.looker.droidify.utility.common.extension.asStateFlow
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
@@ -16,12 +16,19 @@ class FavouritesViewModel @Inject constructor(
     settingsRepository: SettingsRepository,
 ) : ViewModel() {
 
-    val favouriteApps: StateFlow<List<List<Product>>> =
+    val favouriteApps: StateFlow<List<ProductItem>> =
         settingsRepository
             .get { favouriteApps }
             .map { favourites ->
                 favourites.mapNotNull { app ->
-                    Database.ProductAdapter.get(app, null).ifEmpty { null }
+                    val products = Database.ProductAdapter.get(app, null)
+                    val product = products.firstOrNull() ?: return@mapNotNull null
+                    val installed = Database.InstalledAdapter.get(app, null)
+
+                    product.item().apply {
+                        this.installedVersion = installed?.version.orEmpty()
+                        this.canUpdate = product.canUpdate(installed)
+                    }
                 }
             }.asStateFlow(emptyList())
 


### PR DESCRIPTION
Favorites list was not reflecting install/update status because favorite items were missing installed version data, causing isInstalled and canUpdate checks to always fail.

This change ensures favorite entries receive correct status information so installed, updatable, and not-installed apps are visually differentiated, matching the Installed tab behavior.

Tested: Added apps with different states and verified correct styling.

Screenshot:
![Screenshot_2026-02-03-19-40-34-22_2a56200854ad5178a896301eee8a0e67](https://github.com/user-attachments/assets/656c52fe-b28c-4c29-8510-b09427f7d012)