### PR TITLE
fix: favourite state persisted after install

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailViewModel.kt
@@ -64,8 +64,8 @@ class AppDetailViewModel @Inject constructor(
             privacyRepository.getRBLogs(packageName),
             privacyRepository.getLatestDownloadStats(packageName),
             repoAddress,
-            flow { emit(settingsRepository.getInitial()) },
-        ) { products, repositories, installedItem, rblogs, downloads, suggestedAddress, initialSettings ->
+            settingsRepository.data
+        ) { products, repositories, installedItem, rblogs, downloads, suggestedAddress, settings ->
             val idAndRepos = repositories.associateBy { it.id }
             val filteredProducts = products.filter { product ->
                 idAndRepos[product.repositoryId] != null
@@ -76,8 +76,8 @@ class AppDetailViewModel @Inject constructor(
                 rblogs = rblogs,
                 downloads = downloads,
                 installedItem = installedItem,
-                isFavourite = packageName in initialSettings.favouriteApps,
-                allowIncompatibleVersions = initialSettings.incompatibleVersions,
+                isFavourite = packageName in settings.favouriteApps,
+                allowIncompatibleVersions = settings.incompatibleVersions,
                 isSelf = packageName == BuildConfig.APPLICATION_ID,
                 addressIfUnavailable = suggestedAddress,
             )


### PR DESCRIPTION
Fixed an issue where the "Favorite" icon would reset to its initial state after installing an app.

To fix it, I switched from a static snapshot to the reactive settingsRepository.data stream,  ensuring the UI always reflects the most current favorite status from the database, even after installation-triggered refreshes.

Screen Recording:

https://github.com/user-attachments/assets/15cb94ad-f021-4aaf-8dba-6ce123c93541
