### PR TITLE
fix: question mark in section icon

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -484,6 +484,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
     private class SectionViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
         val title = itemView.findViewById<TextView>(R.id.title)!!
         val icon = itemView.findViewById<ShapeableImageView>(R.id.icon)!!
+        val helpIcon = itemView.findViewById<ShapeableImageView>(R.id.help_icon)!!
     }
 
     private class ExpandViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView) {
@@ -1561,14 +1562,6 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                 holder as SectionViewHolder
                 item as Item.SectionItem
 
-                if (item.sectionType == SectionType.VERSIONS) {
-                    holder.icon.load(R.drawable.ic_question_mark)
-                    TooltipCompat.setTooltipText(
-                        holder.icon,
-                        context.getString(R.string.rb_badge_info)
-                    )
-                }
-
                 val expandable = item.items.isNotEmpty() || item.collapseCount > 0
                 holder.itemView.isEnabled = expandable
                 holder.itemView.let {
@@ -1582,7 +1575,21 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
                 val color = context.getColorFromAttr(item.sectionType.colorAttrResId)
                 holder.title.setTextColor(color)
                 holder.title.text = context.getString(item.sectionType.titleResId)
-                holder.icon.isVisible = expandable || item.sectionType == SectionType.VERSIONS
+
+                if (item.sectionType == SectionType.VERSIONS) {
+                    holder.helpIcon.isVisible = true
+                    holder.helpIcon.imageTintList = color
+
+                    TooltipCompat.setTooltipText(
+                        holder.helpIcon,
+                        context.getString(R.string.rb_badge_info)
+                    )
+                } else {
+                    holder.helpIcon.isVisible = false
+                    holder.helpIcon.setOnClickListener(null)
+                }
+
+                holder.icon.isVisible = expandable
                 holder.icon.scaleY = if (item.collapseCount > 0) -1f else 1f
                 holder.icon.imageTintList = color
             }

--- a/app/src/main/res/layout/section_item.xml
+++ b/app/src/main/res/layout/section_item.xml
@@ -5,6 +5,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:background="?android:attr/selectableItemBackground"
     android:orientation="horizontal"
+    android:gravity="center_vertical"
     android:padding="16dp">
 
     <TextView
@@ -13,6 +14,16 @@
         android:layout_height="wrap_content"
         android:layout_weight="1"
         android:singleLine="true" />
+
+    <com.google.android.material.imageview.ShapeableImageView
+        android:id="@+id/help_icon"
+        android:layout_width="wrap_content"
+        android:layout_height="match_parent"
+        android:scaleType="center"
+        android:src="@drawable/ic_question_mark"
+        android:visibility="gone"
+        tools:ignore="ContentDescription"
+        tools:visibility="visible" />
 
     <com.google.android.material.imageview.ShapeableImageView
         android:id="@+id/icon"


### PR DESCRIPTION
Fixes #1228 

This PR resolves the issue caused due to the previous implementation of showing the question mark for specifically "Versions" section header.
Now, as we scroll through to the bottom, and then click on any section, the rest of the sections retain their icons.

https://github.com/user-attachments/assets/191d2b55-92e7-4df2-8c10-c1863c58189f