### PR TITLE
Support Installing apps to private space

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
@@ -297,6 +297,17 @@ fun SettingsScreen(
                 }
             }
 
+            if (settings.installerType == InstallerType.SHIZUKU || settings.installerType == InstallerType.ROOT) {
+                item {
+                    SwitchSettingItem(
+                        title = stringResource(R.string.install_for_all_users),
+                        description = stringResource(R.string.install_for_all_users_summary),
+                        checked = settings.installForAllUsers,
+                        onCheckedChange = viewModel::setInstallForAllUsers,
+                    )
+                }
+            }
+
             item { SettingHeader(title = stringResource(R.string.proxy)) }
 
             item {

--- a/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsViewModel.kt
@@ -194,6 +194,12 @@ class SettingsViewModel @Inject constructor(
         }
     }
 
+    fun setInstallForAllUsers(enabled: Boolean) {
+        viewModelScope.launch {
+            settingsRepository.setInstallForAllUsers(enabled)
+        }
+    }
+
     fun setDownloadStatisticsEnabled(enabled: Boolean) {
         viewModelScope.launch {
             settingsRepository.setDownloadStatisticsEnabled(enabled)

--- a/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/PreferenceSettingsRepository.kt
@@ -186,6 +186,9 @@ class PreferenceSettingsRepository(
     override suspend fun setDeleteApkOnInstall(enable: Boolean) =
         DELETE_APK_ON_INSTALL.update(enable)
 
+    override suspend fun setInstallForAllUsers(enable: Boolean) =
+        INSTALL_FOR_ALL_USERS.update(enable)
+
     override suspend fun setDownloadStatisticsEnabled(enabled: Boolean) =
         DOWNLOAD_STATISTICS_ENABLED.update(enabled)
 
@@ -246,6 +249,7 @@ class PreferenceSettingsRepository(
         val enabledRepoIds =
             preferences[ENABLED_REPO_IDS]?.mapNotNull { it.toIntOrNull() }?.toSet() ?: emptySet()
         val deleteApkOnInstall = preferences[DELETE_APK_ON_INSTALL] ?: false
+        val installForAllUsers = preferences[INSTALL_FOR_ALL_USERS] ?: false
         val downloadStatisticsEnabled = preferences[DOWNLOAD_STATISTICS_ENABLED] ?: true
         val reproducibilityLogsEnabled = preferences[REPRODUCIBILITY_LOGS_ENABLED] ?: true
 
@@ -271,6 +275,7 @@ class PreferenceSettingsRepository(
             homeScreenSwiping = homeScreenSwiping,
             enabledRepoIds = enabledRepoIds,
             deleteApkOnInstall = deleteApkOnInstall,
+            installForAllUsers = installForAllUsers,
             dlStatsEnabled = downloadStatisticsEnabled,
             rbLogsEnabled = reproducibilityLogsEnabled,
         )
@@ -299,6 +304,7 @@ class PreferenceSettingsRepository(
         val FAVOURITE_APPS = stringSetPreferencesKey("key_favourite_apps")
         val HOME_SCREEN_SWIPING = booleanPreferencesKey("key_home_swiping")
         val DELETE_APK_ON_INSTALL = booleanPreferencesKey("key_delete_apk_on_install")
+        val INSTALL_FOR_ALL_USERS = booleanPreferencesKey("key_install_for_all_users")
         val DOWNLOAD_STATISTICS_ENABLED = booleanPreferencesKey("key_download_statistics_enabled")
         val REPRODUCIBILITY_LOGS_ENABLED = booleanPreferencesKey("key_reproducibility_logs_enabled")
         val LEGACY_INSTALLER_COMPONENT_CLASS =
@@ -362,6 +368,7 @@ class PreferenceSettingsRepository(
             set(HOME_SCREEN_SWIPING, settings.homeScreenSwiping)
             set(ENABLED_REPO_IDS, settings.enabledRepoIds.map { it.toString() }.toSet())
             set(DELETE_APK_ON_INSTALL, settings.deleteApkOnInstall)
+            set(INSTALL_FOR_ALL_USERS, settings.installForAllUsers)
             set(DOWNLOAD_STATISTICS_ENABLED, settings.dlStatsEnabled)
             set(REPRODUCIBILITY_LOGS_ENABLED, settings.rbLogsEnabled)
             return this.toPreferences()

--- a/app/src/main/kotlin/com/looker/droidify/datastore/Settings.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/Settings.kt
@@ -47,6 +47,7 @@ data class Settings(
     val homeScreenSwiping: Boolean = true,
     val enabledRepoIds: Set<Int> = emptySet(),
     val deleteApkOnInstall: Boolean = false,
+    val installForAllUsers: Boolean = false,
     val dlStatsEnabled: Boolean = true,
     val rbLogsEnabled: Boolean = true,
 )

--- a/app/src/main/kotlin/com/looker/droidify/datastore/SettingsRepository.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/SettingsRepository.kt
@@ -73,6 +73,8 @@ interface SettingsRepository {
 
     suspend fun setDeleteApkOnInstall(enable: Boolean)
 
+    suspend fun setInstallForAllUsers(enable: Boolean)
+
     suspend fun setDownloadStatisticsEnabled(enabled: Boolean)
 
     suspend fun clearDownloadStatsLastModified()

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -149,8 +149,8 @@ class InstallManager(
             _installer = when (installerType) {
                 InstallerType.LEGACY -> LegacyInstaller(context, settingsRepository)
                 InstallerType.SESSION -> SessionInstaller(context)
-                InstallerType.SHIZUKU -> ShizukuInstaller(context)
-                InstallerType.ROOT -> RootInstaller(context)
+                InstallerType.SHIZUKU -> ShizukuInstaller(context, settingsRepository)
+                InstallerType.ROOT -> RootInstaller(context, settingsRepository)
             }
         }
     }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
@@ -2,6 +2,7 @@ package com.looker.droidify.installer.installers.root
 
 import android.content.Context
 import com.looker.droidify.data.model.PackageName
+import com.looker.droidify.datastore.SettingsRepository
 import com.looker.droidify.installer.installers.Installer
 import com.looker.droidify.installer.installers.uninstallPackage
 import com.looker.droidify.installer.model.InstallItem
@@ -12,24 +13,32 @@ import com.topjohnwu.superuser.Shell
 import kotlin.coroutines.resume
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-class RootInstaller(private val context: Context) : Installer {
+class RootInstaller(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository
+) : Installer {
 
     override suspend fun install(
         installItem: InstallItem,
-    ): InstallState = suspendCancellableCoroutine { cont ->
-        val releaseFile = Cache.getReleaseFile(context, installItem.installFileName)
-        val installCommand = INSTALL_COMMAND.format(
-            releaseFile.absolutePath,
-            currentUser(),
-            context.packageName,
-            releaseFile.length(),
-        )
-        Shell.cmd(installCommand).submit { shellResult ->
-            val result = if (shellResult.isSuccess) InstallState.Installed
-            else InstallState.Failed
-            cont.resume(result)
-            val deleteCommand = DELETE_COMMAND.format(utilBox(), releaseFile.absolutePath)
-            Shell.cmd(deleteCommand).submit()
+    ): InstallState {
+        val installForAllUsers = settingsRepository.getInitial().installForAllUsers
+        val userArg = if (installForAllUsers) "all" else currentUser()
+
+        return suspendCancellableCoroutine { cont ->
+            val releaseFile = Cache.getReleaseFile(context, installItem.installFileName)
+            val installCommand = INSTALL_COMMAND.format(
+                releaseFile.absolutePath,
+                userArg,
+                context.packageName,
+                releaseFile.length(),
+            )
+            Shell.cmd(installCommand).submit { shellResult ->
+                val result = if (shellResult.isSuccess) InstallState.Installed
+                else InstallState.Failed
+                cont.resume(result)
+                val deleteCommand = DELETE_COMMAND.format(utilBox(), releaseFile.absolutePath)
+                Shell.cmd(deleteCommand).submit()
+            }
         }
     }
 

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
@@ -2,6 +2,7 @@ package com.looker.droidify.installer.installers.shizuku
 
 import android.content.Context
 import com.looker.droidify.data.model.PackageName
+import com.looker.droidify.datastore.SettingsRepository
 import com.looker.droidify.installer.installers.Installer
 import com.looker.droidify.installer.installers.uninstallPackage
 import com.looker.droidify.installer.model.InstallItem
@@ -12,9 +13,13 @@ import com.looker.droidify.utility.common.extension.size
 import java.io.BufferedReader
 import java.io.InputStream
 import kotlin.coroutines.resume
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.suspendCancellableCoroutine
 
-class ShizukuInstaller(private val context: Context) : Installer {
+class ShizukuInstaller(
+    private val context: Context,
+    private val settingsRepository: SettingsRepository
+) : Installer {
 
     companion object {
         private val SESSION_ID_REGEX = Regex("(?<=\\[).+?(?=])")
@@ -22,50 +27,55 @@ class ShizukuInstaller(private val context: Context) : Installer {
 
     override suspend fun install(
         installItem: InstallItem,
-    ): InstallState = suspendCancellableCoroutine { cont ->
-        var sessionId: String? = null
-        val file = Cache.getReleaseFile(context, installItem.installFileName)
-        try {
-            val fileSize = file.length()
-            if (fileSize == 0L) {
-                cont.cancel()
-                error("File is not valid: Size ${file.size}")
-            }
-            if (cont.isCompleted) return@suspendCancellableCoroutine
-            val installerPackage = context.packageName
-            file.inputStream().use {
-                val createCommand =
-                    if (SdkCheck.isNougat) {
-                        "pm install-create --user current -i $installerPackage -S $fileSize"
-                    } else {
-                        "pm install-create -i $installerPackage -S $fileSize"
-                    }
-                val createResult = exec(createCommand)
-                sessionId = SESSION_ID_REGEX.find(createResult.out)?.value
-                    ?: run {
+    ): InstallState {
+        val installForAllUsers = settingsRepository.getInitial().installForAllUsers
+        val userArg = if (installForAllUsers) "all" else "current"
+
+        return suspendCancellableCoroutine { cont ->
+            var sessionId: String? = null
+            val file = Cache.getReleaseFile(context, installItem.installFileName)
+            try {
+                val fileSize = file.length()
+                if (fileSize == 0L) {
+                    cont.cancel()
+                    error("File is not valid: Size ${file.size}")
+                }
+                if (cont.isCompleted) return@suspendCancellableCoroutine
+                val installerPackage = context.packageName
+                file.inputStream().use {
+                    val createCommand =
+                        if (SdkCheck.isNougat) {
+                            "pm install-create --user $userArg -i $installerPackage -S $fileSize"
+                        } else {
+                            "pm install-create -i $installerPackage -S $fileSize"
+                        }
+                    val createResult = exec(createCommand)
+                    sessionId = SESSION_ID_REGEX.find(createResult.out)?.value
+                        ?: run {
+                            cont.cancel()
+                            error("Failed to create install session")
+                        }
+                    if (cont.isCompleted) return@suspendCancellableCoroutine
+
+                    val writeResult = exec("pm install-write -S $fileSize $sessionId base -", it)
+                    if (writeResult.resultCode != 0) {
                         cont.cancel()
-                        error("Failed to create install session")
+                        error("Failed to write APK to session $sessionId")
                     }
-                if (cont.isCompleted) return@suspendCancellableCoroutine
+                    if (cont.isCompleted) return@suspendCancellableCoroutine
 
-                val writeResult = exec("pm install-write -S $fileSize $sessionId base -", it)
-                if (writeResult.resultCode != 0) {
-                    cont.cancel()
-                    error("Failed to write APK to session $sessionId")
+                    val commitResult = exec("pm install-commit $sessionId")
+                    if (commitResult.resultCode != 0) {
+                        cont.cancel()
+                        error("Failed to commit install session $sessionId")
+                    }
+                    if (cont.isCompleted) return@suspendCancellableCoroutine
+                    cont.resume(InstallState.Installed)
                 }
-                if (cont.isCompleted) return@suspendCancellableCoroutine
-
-                val commitResult = exec("pm install-commit $sessionId")
-                if (commitResult.resultCode != 0) {
-                    cont.cancel()
-                    error("Failed to commit install session $sessionId")
-                }
-                if (cont.isCompleted) return@suspendCancellableCoroutine
-                cont.resume(InstallState.Installed)
+            } catch (_: Exception) {
+                if (sessionId != null) exec("pm install-abandon $sessionId")
+                cont.resume(InstallState.Failed)
             }
-        } catch (_: Exception) {
-            if (sessionId != null) exec("pm install-abandon $sessionId")
-            cont.resume(InstallState.Failed)
         }
     }
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -107,6 +107,8 @@
     <string name="legacyInstallerComponent">Legacy installer component</string>
     <string name="delete_apk_on_install">Delete APK on install</string>
     <string name="delete_apk_on_install_summary">Automatically delete APK files after successful installation</string>
+    <string name="install_for_all_users">Install for all users</string>
+    <string name="install_for_all_users_summary">If enabled, installs the app for all users on the device (Root/Shizuku only)</string>
     <string name="unspecified">Unspecified</string>
     <string name="insufficient_storage">Insufficient space</string>
     <string name="insufficient_storage_DESC">There isn\'t enough free space to install this app</string>


### PR DESCRIPTION
Usecase: On some Org owned devices, installing apks is only allowed via ADB (or Shizuku).

Manually installing APKs fail (Screenshot) 
<img width="395" height="307" alt="image" src="https://github.com/user-attachments/assets/b0b0426d-c07e-48ca-99b6-03d3352ada57" />


Even with Shizuku access given, Droidify only installs apps in the "main" user profile (Since Shizuku session runs on the main profile) because the command to install the apk has `--user current`

This patch allows an option for a user in main profile install apps inside "Private Space" user profile.

Since `root` mode also uses `pm` commands, this option is applied there as well.