### PR TITLE
Fixed Darkmode on Android 8

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/settings/SettingsFragment.kt
@@ -4,6 +4,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.platform.ComposeView
 import androidx.compose.ui.platform.ViewCompositionStrategy
@@ -13,6 +14,7 @@ import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import com.looker.droidify.compose.settings.SettingsScreen
 import com.looker.droidify.compose.settings.SettingsViewModel
 import com.looker.droidify.compose.theme.DroidifyTheme
+import com.looker.droidify.datastore.model.Theme
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -33,7 +35,13 @@ class SettingsFragment : Fragment() {
             setViewCompositionStrategy(ViewCompositionStrategy.DisposeOnViewTreeLifecycleDestroyed)
             setContent {
                 val settings by viewModel.settings.collectAsStateWithLifecycle()
+                val isDarkTheme = when (settings.theme) {
+                    Theme.DARK, Theme.AMOLED -> true
+                    Theme.LIGHT -> false
+                    Theme.SYSTEM, Theme.SYSTEM_BLACK -> isSystemInDarkTheme()
+                }
                 DroidifyTheme(
+                    darkTheme = isDarkTheme,
                     dynamicColor = settings.dynamicTheme
                 ) {
                     SettingsScreen(


### PR DESCRIPTION
- Passed the app's theme setting into DroidifyTheme so it works on Android 8.
- It didnt work before because on Android 8 isSystemInDarkTheme() is always false i think

Fixed #1289

This PR is a split-up from https://github.com/Droid-ify/client/pull/1293#event-23940605203