### PR TITLE
fix(shizuku): use permission check for existence of shizuku

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/InstallerPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/InstallerPermission.kt
@@ -16,14 +16,15 @@ import kotlin.coroutines.resume
 private const val SHIZUKU_PERMISSION_REQUEST_CODE = 87263
 
 fun launchShizuku(context: Context) {
-    val activities =
-        context.packageManager.getLauncherActivities(ShizukuProvider.MANAGER_APPLICATION_ID)
+    val packageName = context.shizukuPackageName()
+        ?: ShizukuProvider.MANAGER_APPLICATION_ID
+    val activities = context.packageManager.getLauncherActivities(packageName)
     if (activities.isEmpty()) return
     val intent = intent(Intent.ACTION_MAIN) {
         addCategory(Intent.CATEGORY_LAUNCHER)
         setComponent(
             ComponentName(
-                ShizukuProvider.MANAGER_APPLICATION_ID,
+                packageName,
                 activities.first().first,
             ),
         )
@@ -36,8 +37,16 @@ fun initSui(context: Context) = Sui.init(context.packageName)
 
 fun isSuiAvailable() = Sui.isSui()
 
+private fun Context.shizukuPermissionInfo() =
+    runCatching {
+        packageManager.getPermissionInfo(ShizukuProvider.PERMISSION, 0)
+    }.getOrNull()
+
+private fun Context.shizukuPackageName() = shizukuPermissionInfo()?.packageName
+
 fun isShizukuInstalled(context: Context) =
-    context.packageManager.getPackageInfoCompat(ShizukuProvider.MANAGER_APPLICATION_ID) != null
+    context.shizukuPermissionInfo() != null ||
+        context.packageManager.getPackageInfoCompat(ShizukuProvider.MANAGER_APPLICATION_ID) != null
 
 fun isShizukuAlive() = Shizuku.pingBinder()
 


### PR DESCRIPTION
This allows users with hidden shizuku app to use the shizuku installer in droidify. Tested in my Samsung S26 Ultra with [this shizuku](https://github.com/thedjchi/Shizuku) from @thedjchi. For more info, check this [comment](https://github.com/thedjchi/Shizuku/issues/89#issuecomment-3881900562)