### PR TITLE
fix: added mapping for android sdk 37 for app releases details

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/utility/common/SdkCheck.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/common/SdkCheck.kt
@@ -71,5 +71,6 @@ val sdkName by lazy {
         34 to "14",
         35 to "15",
         36 to "16",
+        37 to "17"
     )
 }


### PR DESCRIPTION
Fixes #1317
Added mapping for Android SDK version 37 to Android 17.

<img width="1080" height="2400" alt="Screenshot_2026-04-29-23-25-33-18_2a56200854ad5178a896301eee8a0e67" src="https://github.com/user-attachments/assets/887f0c60-d086-4979-af54-73479b4ab101" />
