### PR TITLE
fix: Register package receiver as RECEIVER_NOT_EXPORTED on API 33+

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/Droidify.kt
+++ b/app/src/main/kotlin/com/looker/droidify/Droidify.kt
@@ -6,6 +6,7 @@ import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
 import android.content.IntentFilter
+import android.os.Build
 import androidx.appcompat.app.AppCompatDelegate
 import androidx.hilt.work.HiltWorkerFactory
 import androidx.work.Configuration
@@ -98,14 +99,18 @@ class Droidify : Application(), SingletonImageLoader.Factory, Configuration.Prov
             Database.InstalledAdapter.putAll(installedItems)
         }
         appScope.launch {
-            registerReceiver(
-                InstalledAppReceiver(packageManager),
-                IntentFilter().apply {
-                    addAction(Intent.ACTION_PACKAGE_ADDED)
-                    addAction(Intent.ACTION_PACKAGE_REMOVED)
-                    addDataScheme("package")
-                },
-            )
+            val filter = IntentFilter().apply {
+                addAction(Intent.ACTION_PACKAGE_ADDED)
+                addAction(Intent.ACTION_PACKAGE_REMOVED)
+                addDataScheme("package")
+            }
+            val receiver = InstalledAppReceiver(packageManager)
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+                registerReceiver(receiver, filter, Context.RECEIVER_NOT_EXPORTED)
+            } else {
+                @Suppress("UnspecifiedRegisterReceiverFlag")
+                registerReceiver(receiver, filter)
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Registers `InstalledAppReceiver` with `RECEIVER_NOT_EXPORTED` on API 33+.

Part of a **5-PR replacement stack** for closed #1339 (per maintainer feedback on large one-shot PRs).

**PR A of 5** — independent; can merge without other stack PRs.

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] Install/uninstall on API 33+; verify installed-apps DB updates


Made with [Cursor](https://cursor.com)