### PR TITLE
feat: Dhizuku installer backend

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.looker.droidify"
-        minSdk = 23
+        minSdk = 26
         versionName = latestVersionName
         versionCode = 710
 
@@ -97,6 +97,7 @@ android {
     }
 
     buildFeatures {
+        aidl = true
         compose = true
         viewBinding = true
         buildConfig = true
@@ -200,6 +201,7 @@ dependencies {
 
     implementation(libs.libsu.core)
     implementation(libs.bundles.shizuku)
+    implementation(libs.dhizuku.api)
 
     implementation(libs.jackson.core)
     implementation(libs.serialization)

--- a/app/proguard.pro
+++ b/app/proguard.pro
@@ -7,3 +7,19 @@
 -dontwarn kotlinx.serialization.KSerializer
 -dontwarn kotlinx.serialization.Serializable
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+# Dhizuku UserService — class name is passed via ComponentName; R8 must not rename it.
+-keep class com.looker.droidify.installer.installers.dhizuku.DroidifyDhizukuInstallerService { *; }
+-keepclassmembers class com.looker.droidify.installer.installers.dhizuku.DroidifyDhizukuInstallerService {
+    <init>(android.content.Context);
+    <init>();
+}
+
+# AIDL-generated Stub/Proxy classes for IPC between app and Dhizuku process
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService { *; }
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService$Stub { *; }
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService$Stub$Proxy { *; }
+
+# Dhizuku library internals
+-keep class com.rosan.dhizuku.** { *; }
+-dontwarn com.rosan.dhizuku.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="com.rosan.dhizuku.permission.API" />
 
     <uses-feature
         android:name="android.software.leanback"
@@ -224,5 +225,10 @@
         </receiver>
 
     </application>
+
+    <queries>
+        <package android:name="com.rosan.dhizuku" />
+        <provider android:authorities="com.rosan.dhizuku.server.provider" />
+    </queries>
 
 </manifest>

--- a/app/src/main/aidl/com/looker/droidify/installer/installers/dhizuku/IDhizukuInstallerService.aidl
+++ b/app/src/main/aidl/com/looker/droidify/installer/installers/dhizuku/IDhizukuInstallerService.aidl
@@ -1,0 +1,7 @@
+package com.looker.droidify.installer.installers.dhizuku;
+
+interface IDhizukuInstallerService {
+    int installPackage(in android.os.ParcelFileDescriptor pfd, long fileSize, String expectedPackageName, long expectedVersionCode, String installerPackageName);
+    void destroy();
+    int uninstallPackage(String packageName);
+}

--- a/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
@@ -482,6 +482,7 @@ private fun InstallerTypeSetting(
                 InstallerType.LEGACY -> stringResource(R.string.legacy_installer)
                 InstallerType.SESSION -> stringResource(R.string.session_installer)
                 InstallerType.SHIZUKU -> stringResource(R.string.shizuku_installer)
+                InstallerType.DHIZUKU -> stringResource(R.string.dhizuku_installer)
                 InstallerType.ROOT -> stringResource(R.string.root_installer)
             }
         },

--- a/app/src/main/kotlin/com/looker/droidify/datastore/model/InstallerType.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/model/InstallerType.kt
@@ -6,6 +6,7 @@ enum class InstallerType {
     LEGACY,
     SESSION,
     SHIZUKU,
+    DHIZUKU,
     ROOT,
     ;
 

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -1,6 +1,7 @@
 package com.looker.droidify.installer
 
 import android.content.Context
+import android.util.Log
 import com.looker.droidify.data.model.PackageName
 import com.looker.droidify.database.Database
 import com.looker.droidify.datastore.SettingsRepository
@@ -16,14 +17,16 @@ import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.service.SyncService
 import com.looker.droidify.utility.common.Constants
 import com.looker.droidify.utility.common.cache.Cache
-import com.looker.droidify.utility.common.extension.addAndCompute
-import com.looker.droidify.utility.common.extension.filter
+import com.looker.droidify.utility.common.extension.getPackageInfoCompat
 import com.looker.droidify.utility.common.extension.notificationManager
 import com.looker.droidify.utility.common.extension.updateAsMutable
+import com.looker.droidify.utility.common.log
+import com.looker.droidify.utility.extension.toInstalledItem
 import com.looker.droidify.utility.notifications.createInstallNotification
 import com.looker.droidify.utility.notifications.installNotification
 import com.looker.droidify.utility.notifications.removeInstallNotification
 import com.looker.droidify.utility.notifications.updatesAvailableNotification
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -32,17 +35,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
 
 class InstallManager(
     private val context: Context,
     private val settingsRepository: SettingsRepository,
 ) {
 
-    private val installItems = Channel<InstallItem>()
-    private val uninstallItems = Channel<PackageName>()
+    private val installItems = Channel<InstallItem>(Channel.UNLIMITED)
+    private val uninstallItems = Channel<PackageName>(Channel.UNLIMITED)
+    private val installCompletions = ConcurrentHashMap<String, CompletableDeferred<InstallState>>()
 
     val state = MutableStateFlow<Map<PackageName, InstallState>>(emptyMap())
 
@@ -75,6 +81,18 @@ class InstallManager(
         installItems.send(installItem)
     }
 
+    suspend fun installAndAwait(installItem: InstallItem): InstallState {
+        val key = installItem.packageName.name
+        installCompletions[key]?.let { inFlight ->
+            log("Joining in-flight install: $key", TAG)
+            return inFlight.await()
+        }
+        val deferred = CompletableDeferred<InstallState>()
+        installCompletions[key] = deferred
+        installItems.send(installItem)
+        return deferred.await()
+    }
+
     suspend infix fun uninstall(packageName: PackageName) {
         uninstallItems.send(packageName)
     }
@@ -92,55 +110,92 @@ class InstallManager(
     }
 
     private fun CoroutineScope.installer() = launch {
-        val currentQueue = mutableSetOf<String>()
-        installItems.filter { item ->
-            currentQueue.addAndCompute(item.packageName.name) { isAdded ->
-                if (isAdded) {
-                    updateState { put(item.packageName, InstallState.Pending) }
-                }
-            }
-        }.consumeEach { item ->
-            if (state.value.containsKey(item.packageName)) {
+        installItems.consumeEach { item ->
+            val key = item.packageName.name
+            log("Install started: $key", TAG)
+            val result = try {
                 updateState { put(item.packageName, InstallState.Installing) }
                 notificationManager?.installNotification(
-                    packageName = item.packageName.name,
+                    packageName = key,
                     notification = context.createInstallNotification(
-                        appName = item.packageName.name,
+                        appName = key,
                         state = InstallState.Installing,
                     ),
                 )
-                val result = installer.use { it.install(item) }
-                if (result == InstallState.Installed && installer !is LegacyInstaller) {
-                    if (deleteApkPreference.first()) {
-                        val apkFile = Cache.getReleaseFile(context, item.installFileName)
-                        apkFile.delete()
+                try {
+                    installer.use { it.install(item) }
+                } catch (e: Exception) {
+                    log("Install failed: $key — ${e.message}", TAG, Log.ERROR)
+                    InstallState.Failed
+                }.also { installResult ->
+                    notificationManager?.removeInstallNotification(key)
+                    if (installResult == InstallState.Installed) {
+                        updateState { remove(item.packageName) }
+                        log("Install succeeded: $key", TAG)
+                        if (installer !is LegacyInstaller) {
+                            refreshInstalledPackage(key)
+                            if (deleteApkPreference.first() && !SyncService.autoUpdating) {
+                                Cache.getReleaseFile(context, item.installFileName).delete()
+                            }
+                        }
+                        if (SyncService.autoUpdating) {
+                            val updates = Database.ProductAdapter.getUpdates(skipSignature.first())
+                            when {
+                                updates.isEmpty() -> {
+                                    SyncService.autoUpdating = false
+                                    notificationManager?.cancel(Constants.NOTIFICATION_ID_UPDATES)
+                                    log("Update-all batch complete", TAG)
+                                }
+                                updates.map { it.packageName } != SyncService.autoUpdateStartedFor -> {
+                                    notificationManager?.notify(
+                                        Constants.NOTIFICATION_ID_UPDATES,
+                                        updatesAvailableNotification(context, updates),
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        updateState { put(item.packageName, installResult) }
+                        log("Install finished with $installResult: $key", TAG, Log.WARN)
                     }
                 }
-                if (result == InstallState.Installed && SyncService.autoUpdating) {
-                    val updates = Database.ProductAdapter.getUpdates(skipSignature.first())
-                    when {
-                        updates.isEmpty() -> {
-                            SyncService.autoUpdating = false
-                            notificationManager?.cancel(Constants.NOTIFICATION_ID_UPDATES)
-                        }
-                        updates.map { it.packageName } != SyncService.autoUpdateStartedFor -> {
-                            notificationManager?.notify(
-                                Constants.NOTIFICATION_ID_UPDATES,
-                                updatesAvailableNotification(context, updates),
-                            )
-                        }
-                    }
-                }
-                notificationManager?.removeInstallNotification(item.packageName.name)
-                updateState { put(item.packageName, result) }
-                currentQueue.remove(item.packageName.name)
+            } catch (e: Exception) {
+                log("Install queue error: $key — ${e.message}", TAG, Log.ERROR)
+                InstallState.Failed
             }
+            installCompletions.remove(key)?.complete(result)
         }
     }
 
     private fun CoroutineScope.uninstaller() = launch {
-        uninstallItems.consumeEach {
-            installer.uninstall(it)
+        uninstallItems.consumeEach { packageName ->
+            val key = packageName.name
+            log("Uninstall queued: $key", TAG)
+            updateState { put(packageName, InstallState.Uninstalling) }
+            try {
+                log("Uninstall started: $key", TAG)
+                notificationManager?.installNotification(
+                    packageName = key,
+                    notification = context.createInstallNotification(
+                        appName = key,
+                        state = InstallState.Uninstalling,
+                    ),
+                )
+                try {
+                    installer.uninstall(packageName)
+                } catch (e: Exception) {
+                    log("Uninstall failed: $key — ${e.message}", TAG, Log.ERROR)
+                    throw e
+                }
+                notificationManager?.removeInstallNotification(key)
+                updateState { remove(packageName) }
+                refreshUninstalledPackage(key)
+                log("Uninstall succeeded: $key", TAG)
+            } catch (e: Exception) {
+                log("Uninstall error (cleanup): $key — ${e.message}", TAG, Log.ERROR)
+                notificationManager?.removeInstallNotification(key)
+                updateState { remove(packageName) }
+            }
         }
     }
 
@@ -157,5 +212,40 @@ class InstallManager(
 
     private inline fun updateState(block: MutableMap<PackageName, InstallState>.() -> Unit) {
         state.update { it.updateAsMutable(block) }
+    }
+
+    /**
+     * Silent installers (Session/Shizuku/Dhizuku) may not deliver [Intent.ACTION_PACKAGE_ADDED]
+     * to our dynamic receiver when install runs in another UID. Refresh the local DB explicitly.
+     */
+    private suspend fun refreshInstalledPackage(packageName: String) {
+        repeat(REFRESH_INSTALLED_ATTEMPTS) { attempt ->
+            val packageInfo = context.packageManager.getPackageInfoCompat(packageName)
+            if (packageInfo != null) {
+                Database.InstalledAdapter.put(packageInfo.toInstalledItem())
+                return
+            }
+            if (attempt < REFRESH_INSTALLED_ATTEMPTS - 1) {
+                delay(REFRESH_INSTALLED_DELAY_MS)
+            }
+        }
+    }
+
+    private suspend fun refreshUninstalledPackage(packageName: String) {
+        repeat(REFRESH_INSTALLED_ATTEMPTS) { attempt ->
+            if (context.packageManager.getPackageInfoCompat(packageName) == null) {
+                Database.InstalledAdapter.delete(packageName)
+                return
+            }
+            if (attempt < REFRESH_INSTALLED_ATTEMPTS - 1) {
+                delay(REFRESH_INSTALLED_DELAY_MS)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "DroidifyUpdateAll"
+        private const val REFRESH_INSTALLED_ATTEMPTS = 20
+        private const val REFRESH_INSTALLED_DELAY_MS = 250L
     }
 }

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -12,6 +12,7 @@ import com.looker.droidify.installer.installers.LegacyInstaller
 import com.looker.droidify.installer.installers.root.RootInstaller
 import com.looker.droidify.installer.installers.session.SessionInstaller
 import com.looker.droidify.installer.installers.shizuku.ShizukuInstaller
+import com.looker.droidify.installer.installers.dhizuku.DhizukuInstaller
 import com.looker.droidify.installer.model.InstallItem
 import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.service.SyncService
@@ -205,6 +206,7 @@ class InstallManager(
                 InstallerType.LEGACY -> LegacyInstaller(context, settingsRepository)
                 InstallerType.SESSION -> SessionInstaller(context)
                 InstallerType.SHIZUKU -> ShizukuInstaller(context)
+                InstallerType.DHIZUKU -> DhizukuInstaller(context)
                 InstallerType.ROOT -> RootInstaller(context)
             }
         }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstallManager.kt
@@ -1,0 +1,390 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.DeadObjectException
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
+import android.os.RemoteException
+import android.util.Log
+import com.rosan.dhizuku.api.Dhizuku
+import com.rosan.dhizuku.api.DhizukuUserServiceArgs
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class DhizukuInstallManager(private val context: Context) {
+    private val bindLock = Any()
+
+    @Volatile
+    private var installerService: IDhizukuInstallerService? = null
+
+    @Volatile
+    private var serviceConnection: ServiceConnection? = null
+
+    fun installApk(apkPath: String) {
+        if (!Dhizuku.init(context)) {
+            throw IllegalStateException("Dhizuku is not available")
+        }
+        if (!Dhizuku.isPermissionGranted()) {
+            throw SecurityException("Dhizuku permission denied")
+        }
+
+        val file = File(apkPath)
+        if (!file.exists() || file.length() <= 0L) {
+            throw IllegalArgumentException("APK file missing or empty")
+        }
+
+        var lastError: Exception? = null
+        repeat(MAX_INSTALL_ATTEMPTS) { attempt ->
+            if (attempt > 0) {
+                Log.w(TAG, "Retrying Dhizuku install after rebinding (attempt ${attempt + 1})")
+                synchronized(dhizukuOperationLock) {
+                    resetUserServiceState()
+                }
+            }
+
+            try {
+                val service = bindInstallerService(clearCache = attempt == 0)
+                    ?: throw IllegalStateException("Failed to bind Dhizuku installer service")
+                performInstall(service, file)
+                return
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt == MAX_INSTALL_ATTEMPTS - 1 || !shouldRetryBind(e)) {
+                    throw e
+                }
+                if (isDhizukuStartupError(e)) {
+                    launchDhizuku(context)
+                    Thread.sleep(DHIZUKU_STARTUP_SETTLE_MS)
+                }
+                Log.w(TAG, "Dhizuku install failed, will rebind: ${e.message}")
+            }
+        }
+
+        throw lastError ?: IllegalStateException("Dhizuku install failed")
+    }
+
+    fun uninstallPackage(packageName: String) {
+        if (!Dhizuku.init(context)) {
+            throw IllegalStateException("Dhizuku is not available")
+        }
+        if (!Dhizuku.isPermissionGranted()) {
+            throw SecurityException("Dhizuku permission denied")
+        }
+
+        var lastError: Exception? = null
+        repeat(MAX_INSTALL_ATTEMPTS) { attempt ->
+            if (attempt > 0) {
+                Log.w(TAG, "Retrying Dhizuku uninstall after rebinding (attempt ${attempt + 1})")
+                synchronized(dhizukuOperationLock) {
+                    resetUserServiceState()
+                }
+            }
+
+            try {
+                val service = bindInstallerService(clearCache = attempt == 0)
+                    ?: throw IllegalStateException("Failed to bind Dhizuku installer service")
+                val result = service.uninstallPackage(packageName)
+                if (result == DroidifyDhizukuInstallerService.STATUS_SUCCESS) {
+                    return
+                }
+                throw IllegalStateException("Uninstall failed with code $result")
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt == MAX_INSTALL_ATTEMPTS - 1 || !shouldRetryBind(e)) {
+                    throw e
+                }
+                if (isDhizukuStartupError(e)) {
+                    launchDhizuku(context)
+                    Thread.sleep(DHIZUKU_STARTUP_SETTLE_MS)
+                }
+                Log.w(TAG, "Dhizuku uninstall failed, will rebind: ${e.message}")
+            }
+        }
+
+        throw lastError ?: IllegalStateException("Dhizuku uninstall failed")
+    }
+
+    /** Bind only — remote install/uninstall RPC runs outside the lock so ops can overlap. */
+    private fun bindInstallerService(clearCache: Boolean): IDhizukuInstallerService? =
+        synchronized(dhizukuOperationLock) {
+            if (clearCache) {
+                clearStaleDhizukuClientCache(userServiceArgs())
+            }
+            getOrBindService()
+        }
+
+    private fun performInstall(service: IDhizukuInstallerService, file: File) {
+        val (expectedPackageName, expectedVersionCode) = readApkIdentity(file.absolutePath)
+        var result = openAndInstall(
+            service,
+            file,
+            expectedPackageName,
+            expectedVersionCode,
+            null,
+        )
+
+        if (result == DroidifyDhizukuInstallerService.STATUS_PENDING_USER_ACTION_REQUIRED) {
+            result = openAndInstall(
+                service,
+                file,
+                expectedPackageName,
+                expectedVersionCode,
+                context.packageName,
+            )
+        }
+
+        when (result) {
+            DroidifyDhizukuInstallerService.STATUS_SUCCESS -> Unit
+            DroidifyDhizukuInstallerService.STATUS_PENDING_USER_ACTION_REQUIRED ->
+                throw IllegalStateException("Install requires user action")
+            else -> throw IllegalStateException("Install failed with code $result")
+        }
+    }
+
+    private fun openAndInstall(
+        service: IDhizukuInstallerService,
+        file: File,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+    ): Int {
+        try {
+            return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+                service.installPackage(
+                    pfd,
+                    file.length(),
+                    expectedPackageName,
+                    expectedVersionCode,
+                    installerPackageName,
+                )
+            }
+        } catch (e: RemoteException) {
+            throw IllegalStateException(formatRemoteError(e), e)
+        } catch (e: DeadObjectException) {
+            throw IllegalStateException("Dhizuku installer service disconnected", e)
+        }
+    }
+
+    private fun getOrBindService(): IDhizukuInstallerService? {
+        synchronized(bindLock) {
+            installerService?.let { service ->
+                val alive = try {
+                    service.asBinder().pingBinder()
+                } catch (_: Exception) {
+                    false
+                }
+                if (alive) {
+                    return service
+                }
+                invalidateServiceLocked()
+                clearStaleDhizukuClientCache(userServiceArgs())
+                stopUserServiceQuietly()
+            }
+        }
+        return bindServiceSync()
+    }
+
+    private fun userServiceArgs(): DhizukuUserServiceArgs {
+        val componentName = ComponentName(
+            context.packageName,
+            DroidifyDhizukuInstallerService::class.java.name,
+        )
+        return DhizukuUserServiceArgs(componentName)
+    }
+
+    private fun invalidateServiceLocked() {
+        val conn = serviceConnection
+        installerService = null
+        serviceConnection = null
+        if (conn != null) {
+            try {
+                Dhizuku.unbindUserService(conn)
+            } catch (e: Exception) {
+                Log.w(TAG, "unbindUserService failed: ${e.message}")
+            }
+        }
+    }
+
+    private fun resetUserServiceState() {
+        invalidateServiceLocked()
+        clearStaleDhizukuClientCache(userServiceArgs())
+        stopUserServiceQuietly()
+    }
+
+    private fun stopUserServiceQuietly() {
+        try {
+            Dhizuku.stopUserService(userServiceArgs())
+            Thread.sleep(STOP_SETTLE_MS)
+        } catch (e: Exception) {
+            Log.w(TAG, "stopUserService failed: ${e.message}")
+        }
+    }
+
+    private fun clearStaleDhizukuClientCache(args: DhizukuUserServiceArgs) {
+        try {
+            val clazz = Class.forName("com.rosan.dhizuku.api.DhizukuServiceConnections")
+            val servicesField = clazz.getDeclaredField("services")
+            servicesField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val services = servicesField.get(null) as MutableMap<String, IBinder>
+            val token = args.componentName.flattenToString()
+            if (services.remove(token) != null) {
+                Log.d(TAG, "Cleared stale Dhizuku client binder cache for $token")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to clear Dhizuku client cache: ${e.message}")
+        }
+    }
+
+    private fun isBinderAlive(binder: IBinder?): Boolean {
+        if (binder == null) return false
+        return try {
+            binder.pingBinder()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun bindServiceSync(attempt: Int = 0): IDhizukuInstallerService? {
+        if (attempt >= MAX_BIND_ATTEMPTS) {
+            Log.e(TAG, "Exceeded max bind attempts ($MAX_BIND_ATTEMPTS)")
+            return null
+        }
+
+        if (attempt > 0) {
+            clearStaleDhizukuClientCache(userServiceArgs())
+            Thread.sleep(BIND_RETRY_DELAY_MS * attempt)
+            if (attempt >= 2) {
+                stopUserServiceQuietly()
+            }
+        }
+
+        val args = userServiceArgs()
+        val latch = CountDownLatch(1)
+        var boundService: IDhizukuInstallerService? = null
+        var disconnectedDuringBind = false
+
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val alive = isBinderAlive(binder)
+                if (!alive) {
+                    clearStaleDhizukuClientCache(args)
+                    return
+                }
+                boundService = IDhizukuInstallerService.Stub.asInterface(binder)
+                synchronized(bindLock) {
+                    installerService = boundService
+                    serviceConnection = this
+                }
+                latch.countDown()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                disconnectedDuringBind = true
+                synchronized(bindLock) {
+                    installerService = null
+                    serviceConnection = null
+                }
+                latch.countDown()
+            }
+        }
+
+        val bound = Dhizuku.bindUserService(args, connection)
+        if (!bound) {
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            return bindServiceSync(attempt + 1)
+        }
+
+        val connected = latch.await(BIND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!connected) {
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            clearStaleDhizukuClientCache(args)
+            return bindServiceSync(attempt + 1)
+        }
+
+        val service = boundService
+        val aliveAfterBind = service != null && isBinderAlive(service.asBinder())
+        if (!aliveAfterBind || disconnectedDuringBind) {
+            synchronized(bindLock) {
+                installerService = null
+                serviceConnection = null
+            }
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            clearStaleDhizukuClientCache(args)
+            return bindServiceSync(attempt + 1)
+        }
+
+        return service
+    }
+
+    private fun readApkIdentity(apkPath: String): Pair<String?, Long> {
+        val info = context.packageManager.getPackageArchiveInfo(
+            apkPath,
+            PackageManager.GET_ACTIVITIES,
+        ) ?: return null to -1L
+        info.applicationInfo?.apply {
+            sourceDir = apkPath
+            publicSourceDir = apkPath
+        }
+        val versionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        return info.packageName to versionCode
+    }
+
+    private fun shouldRetryBind(error: Exception): Boolean {
+        if (error is DeadObjectException) return true
+        if (error.cause is DeadObjectException || error.cause is RemoteException) return true
+        return isDhizukuStartupError(error)
+    }
+
+    private fun isDhizukuStartupError(error: Exception): Boolean {
+        val message = buildString {
+            append(error.message.orEmpty())
+            error.cause?.message?.let { append(' ').append(it) }
+        }
+        return message.contains("disconnect", ignoreCase = true) ||
+            message.contains("binder", ignoreCase = true) ||
+            message.contains("connection", ignoreCase = true) ||
+            message.contains("DeadObject", ignoreCase = true) ||
+            message.contains("Failed to bind", ignoreCase = true) ||
+            message.contains("remote call failed", ignoreCase = true) ||
+            message.contains("does not belong", ignoreCase = true) ||
+            message.contains("frozen", ignoreCase = true) ||
+            message.contains("No definition found", ignoreCase = true) ||
+            message.contains("Modules configuration", ignoreCase = true)
+    }
+
+    private fun formatRemoteError(error: RemoteException): String {
+        return error.message?.takeIf { it.isNotBlank() }
+            ?: error.cause?.message?.takeIf { it.isNotBlank() }
+            ?: "Dhizuku installer remote call failed"
+    }
+
+    companion object {
+        private val dhizukuOperationLock = Any()
+        private const val TAG = "DhizukuInstallManager"
+        private const val BIND_TIMEOUT_SECONDS = 15L
+        private const val MAX_INSTALL_ATTEMPTS = 3
+        private const val MAX_BIND_ATTEMPTS = 3
+        private const val STOP_SETTLE_MS = 400L
+        private const val BIND_RETRY_DELAY_MS = 500L
+        private const val DHIZUKU_STARTUP_SETTLE_MS = 1500L
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstaller.kt
@@ -1,0 +1,55 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.Context
+import android.util.Log
+import com.looker.droidify.data.model.PackageName
+import com.looker.droidify.installer.installers.Installer
+import com.looker.droidify.installer.model.InstallItem
+import com.looker.droidify.installer.model.InstallState
+import com.looker.droidify.utility.common.cache.Cache
+import com.looker.droidify.utility.common.extension.getPackageInfoCompat
+import com.looker.droidify.utility.common.extension.size
+import kotlinx.coroutines.delay
+
+class DhizukuInstaller(private val context: Context) : Installer {
+
+    private val installManager = DhizukuInstallManager(context)
+
+    override suspend fun install(installItem: InstallItem): InstallState {
+        val file = Cache.getReleaseFile(context, installItem.installFileName)
+        if (file.length() == 0L) {
+            error("File is not valid: Size ${file.size}")
+        }
+        if (!ensureDhizukuInstallerReady(context)) {
+            Log.e(TAG, "Dhizuku not ready for ${installItem.packageName.name}")
+            return InstallState.Failed
+        }
+        return try {
+            installManager.installApk(file.absolutePath)
+            awaitPackageVisible(installItem.packageName.name)
+            InstallState.Installed
+        } catch (e: Exception) {
+            Log.e(TAG, "Dhizuku install failed: ${installItem.packageName.name}", e)
+            InstallState.Failed
+        }
+    }
+
+    private suspend fun awaitPackageVisible(packageName: String) {
+        repeat(PACKAGE_VISIBLE_ATTEMPTS) {
+            if (context.packageManager.getPackageInfoCompat(packageName) != null) return
+            delay(PACKAGE_VISIBLE_DELAY_MS)
+        }
+    }
+
+    override suspend fun uninstall(packageName: PackageName) {
+        installManager.uninstallPackage(packageName.name)
+    }
+
+    override fun close() = Unit
+
+    companion object {
+        private const val TAG = "DhizukuInstaller"
+        private const val PACKAGE_VISIBLE_ATTEMPTS = 20
+        private const val PACKAGE_VISIBLE_DELAY_MS = 250L
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -22,8 +22,15 @@ fun isDhizukuInstalled(context: Context): Boolean =
         false
     }
 
+/**
+ * True when a Dhizuku-compatible server is reachable. [Dhizuku.init] resolves the server from the
+ * active device owner's provider rather than a fixed package, so this also matches third-party
+ * servers such as OwnDroid's built-in Dhizuku server — not only the standalone Dhizuku app. Gating
+ * this on [isDhizukuInstalled] (a hardcoded `com.rosan.dhizuku` lookup) would reject those servers
+ * even when they are running, so the install check is intentionally left out here.
+ */
 fun isDhizukuAlive(context: Context): Boolean =
-    isDhizukuInstalled(context) && try {
+    try {
         Dhizuku.init(context)
     } catch (_: Exception) {
         false

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -1,0 +1,116 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import com.looker.droidify.utility.common.extension.getLauncherActivities
+import com.looker.droidify.utility.common.extension.intent
+import com.rosan.dhizuku.api.Dhizuku
+import com.rosan.dhizuku.api.DhizukuRequestPermissionListener
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
+
+fun isDhizukuInstalled(context: Context): Boolean =
+    try {
+        context.packageManager.getPackageInfo(DHIZUKU_PACKAGE, 0)
+        true
+    } catch (_: PackageManager.NameNotFoundException) {
+        false
+    }
+
+fun isDhizukuAlive(context: Context): Boolean =
+    isDhizukuInstalled(context) && try {
+        Dhizuku.init(context)
+    } catch (_: Exception) {
+        false
+    }
+
+fun isDhizukuGranted(): Boolean =
+    try {
+        Dhizuku.isPermissionGranted()
+    } catch (_: Exception) {
+        false
+    }
+
+fun launchDhizuku(context: Context) {
+    if (!isDhizukuInstalled(context)) return
+    val activities = context.packageManager.getLauncherActivities(DHIZUKU_PACKAGE)
+    if (activities.isEmpty()) return
+    val launchIntent = intent(Intent.ACTION_MAIN) {
+        addCategory(Intent.CATEGORY_LAUNCHER)
+        setComponent(
+            ComponentName(
+                DHIZUKU_PACKAGE,
+                activities.first().first,
+            ),
+        )
+        setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(launchIntent)
+}
+
+private const val DHIZUKU_WAKE_POLL_ATTEMPTS = 15
+private const val DHIZUKU_WAKE_POLL_DELAY_MS = 200L
+private const val DHIZUKU_INSTALLER_READY_ATTEMPTS = 25
+private const val DHIZUKU_INSTALLER_STABILITY_DELAY_MS = 200L
+
+suspend fun ensureDhizukuAlive(context: Context): Boolean {
+    if (isDhizukuAlive(context)) return true
+    if (!isDhizukuInstalled(context)) return false
+    launchDhizuku(context)
+    repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
+        delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+        if (isDhizukuAlive(context)) return true
+    }
+    return false
+}
+
+/** Dhizuku server may throw while Koin is still starting after wake; poll until stable. */
+suspend fun ensureDhizukuGranted(): Boolean {
+    repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
+        if (isDhizukuGranted()) return true
+        delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+    }
+    return isDhizukuGranted()
+}
+
+/**
+ * Wake Dhizuku and wait until permission + DI are stable enough for install/uninstall RPC.
+ * Needed for update-all and other background installs where the UI does not prepare Dhizuku first.
+ */
+suspend fun ensureDhizukuInstallerReady(context: Context): Boolean {
+    if (!ensureDhizukuAlive(context)) return false
+    if (!ensureDhizukuGranted()) return false
+    repeat(DHIZUKU_INSTALLER_READY_ATTEMPTS) {
+        delay(DHIZUKU_INSTALLER_STABILITY_DELAY_MS)
+        if (!isDhizukuAlive(context)) {
+            ensureDhizukuAlive(context)
+            return@repeat
+        }
+        if (isDhizukuGranted()) return true
+    }
+    return isDhizukuAlive(context) && isDhizukuGranted()
+}
+
+suspend fun requestDhizukuPermission(context: Context): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        if (!Dhizuku.init(context)) {
+            continuation.resume(false)
+            return@suspendCancellableCoroutine
+        }
+        if (isDhizukuGranted()) {
+            continuation.resume(true)
+            return@suspendCancellableCoroutine
+        }
+        Dhizuku.requestPermission(object : DhizukuRequestPermissionListener() {
+            override fun onRequestPermission(grantResult: Int) {
+                if (continuation.isActive) {
+                    continuation.resume(grantResult == PackageManager.PERMISSION_GRANTED)
+                }
+            }
+        })
+    }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -4,10 +4,13 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
 import com.looker.droidify.utility.common.extension.getLauncherActivities
 import com.looker.droidify.utility.common.extension.intent
 import com.rosan.dhizuku.api.Dhizuku
 import com.rosan.dhizuku.api.DhizukuRequestPermissionListener
+import com.rosan.dhizuku.shared.DhizukuVariables
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
@@ -64,13 +67,36 @@ private const val DHIZUKU_WAKE_POLL_ATTEMPTS = 15
 private const val DHIZUKU_WAKE_POLL_DELAY_MS = 200L
 private const val DHIZUKU_INSTALLER_READY_ATTEMPTS = 25
 private const val DHIZUKU_INSTALLER_STABILITY_DELAY_MS = 200L
+private const val TAG = "DhizukuPermission"
+
+/**
+ * Gracefully unfreezes the Dhizuku server process. Built-in servers such as OwnDroid keep no
+ * foreground service, so the process is frozen once backgrounded and the first bind returns
+ * "error -74 (sent to frozen apps)". A *real* ContentProvider transaction is AMS-mediated and
+ * unfreezes the target — unlike acquiring the client alone or a raw binder call. Best-effort; the
+ * result is irrelevant, delivering the call is what forces the unfreeze. Callers still poll after.
+ */
+fun wakeDhizukuServer(context: Context) {
+    runCatching {
+        val authority = DhizukuVariables.getProviderAuthorityName(Dhizuku.getOwnerPackageName())
+        val uri = Uri.parse("content://$authority")
+        context.contentResolver.acquireUnstableContentProviderClient(uri)?.use { client ->
+            runCatching { client.call("ping", null, null) }
+        }
+    }.onFailure { Log.w(TAG, "wakeDhizukuServer failed: ${it.message}") }
+}
 
 suspend fun ensureDhizukuAlive(context: Context): Boolean {
     if (isDhizukuAlive(context)) return true
-    if (!isDhizukuInstalled(context)) return false
-    launchDhizuku(context)
+    // Unfreeze a cached server (e.g. OwnDroid) without needing a launcher activity. The standalone
+    // Dhizuku app additionally needs its UI launched to start the server; built-in servers have no
+    // launcher and simply no-op here. Either way, poll until the server answers — and keep waking
+    // it each round, since it can be re-frozen between attempts.
+    wakeDhizukuServer(context)
+    if (isDhizukuInstalled(context)) launchDhizuku(context)
     repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
         delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+        wakeDhizukuServer(context)
         if (isDhizukuAlive(context)) return true
     }
     return false

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
@@ -1,6 +1,7 @@
 package com.looker.droidify.installer.installers.dhizuku
 
 import android.app.PendingIntent
+import android.app.admin.DevicePolicyManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -27,7 +28,6 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
         const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
 
         private const val TAG = "DroidifyDhizuku"
-        private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
         private const val INSTALL_TIMEOUT_SECONDS = 120L
         private const val UNINSTALL_TIMEOUT_SECONDS = 30L
         private const val INSTALL_POLL_INTERVAL_MS = 200L
@@ -292,11 +292,12 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
         serviceContext?.let { ctx ->
             return ctx.applicationContext ?: ctx
         }
-        val app = currentApplicationOrNull()
-        if (app?.packageName == DHIZUKU_PACKAGE) {
-            return app.applicationContext ?: app
-        }
-        return null
+        // No service Context was supplied: accept the host process only if it is the active device
+        // owner. Dhizuku loads this service into the device-owner process regardless of which app
+        // provides the server (the standalone Dhizuku app, OwnDroid's built-in server, ...), so
+        // verify ownership instead of matching a hardcoded package name.
+        val app = currentApplicationOrNull() ?: return null
+        return if (isDeviceOwner(app)) app.applicationContext ?: app else null
     }
 
     private fun verifyInstallSucceeded(
@@ -320,6 +321,14 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
             info.versionCode.toLong()
         }
         return installedVersion >= expectedVersionCode
+    }
+
+    private fun isDeviceOwner(ctx: Context): Boolean = try {
+        val dpm = ctx.getSystemService(Context.DEVICE_POLICY_SERVICE) as? DevicePolicyManager
+        dpm?.isDeviceOwnerApp(ctx.packageName) == true
+    } catch (e: Exception) {
+        Log.w(TAG, "Device-owner check failed", e)
+        false
     }
 
     private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
@@ -1,0 +1,355 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import android.os.RemoteException
+import android.util.Log
+import androidx.annotation.Keep
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@Keep
+class DroidifyDhizukuInstallerService @JvmOverloads constructor(
+    private val serviceContext: Context? = null,
+) : IDhizukuInstallerService.Stub() {
+
+    companion object {
+        const val STATUS_SUCCESS = 0
+        const val STATUS_FAILURE = -1
+        const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
+
+        private const val TAG = "DroidifyDhizuku"
+        private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
+        private const val INSTALL_TIMEOUT_SECONDS = 120L
+        private const val UNINSTALL_TIMEOUT_SECONDS = 30L
+        private const val INSTALL_POLL_INTERVAL_MS = 200L
+        private const val UNINSTALL_POLL_INTERVAL_MS = 200L
+        private const val ACTION_INSTALL_RESULT = "com.looker.droidify.dhizuku.INSTALL_RESULT"
+        private const val ACTION_UNINSTALL_RESULT = "com.looker.droidify.dhizuku.UNINSTALL_RESULT"
+    }
+
+    override fun installPackage(
+        pfd: ParcelFileDescriptor,
+        fileSize: Long,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+    ): Int {
+        Log.d(
+            TAG,
+            "installPackage size=$fileSize expected=$expectedPackageName@$expectedVersionCode " +
+                "installer=$installerPackageName uid=${android.os.Process.myUid()}",
+        )
+
+        val ctx = resolveContext() ?: run {
+            Log.e(TAG, "No application context in Dhizuku process")
+            throw RemoteException("No application context in Dhizuku process")
+        }
+
+        val installer = ctx.packageManager.packageInstaller
+        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
+        }
+        if (fileSize > 0) {
+            params.setSize(fileSize)
+        }
+        installerPackageName?.takeIf { it.isNotBlank() }?.let { name ->
+            try {
+                params.setInstallerPackageName(name)
+            } catch (e: Exception) {
+                Log.w(TAG, "setInstallerPackageName($name) failed: ${e.message}")
+            }
+        }
+
+        var sessionId = -1
+        var session: PackageInstaller.Session? = null
+        var receiver: BroadcastReceiver? = null
+        var committed = false
+        var installError: String? = null
+        return try {
+            sessionId = installer.createSession(params)
+            Log.d(TAG, "createSession id=$sessionId pkg=${ctx.packageName}")
+            session = installer.openSession(sessionId)
+
+            session.openWrite("apk", 0, fileSize).use { out ->
+                ParcelFileDescriptor.AutoCloseInputStream(pfd).use { input ->
+                    val copied = input.copyTo(out)
+                    out.flush()
+                    session.fsync(out)
+                    Log.d(TAG, "streamed $copied bytes to session")
+                }
+            }
+
+            val latch = CountDownLatch(1)
+            val resultRef = AtomicInteger(STATUS_FAILURE)
+            val token = UUID.randomUUID().toString()
+            val action = "$ACTION_INSTALL_RESULT.$token"
+
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    val status = intent.getIntExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_FAILURE,
+                    )
+                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                    Log.d(TAG, "install callback status=$status message=$message")
+                    when (status) {
+                        PackageInstaller.STATUS_SUCCESS -> resultRef.set(STATUS_SUCCESS)
+                        PackageInstaller.STATUS_PENDING_USER_ACTION ->
+                            resultRef.set(STATUS_PENDING_USER_ACTION_REQUIRED)
+                        else -> {
+                            installError = message ?: "PackageInstaller status=$status"
+                            resultRef.set(STATUS_FAILURE)
+                        }
+                    }
+                    latch.countDown()
+                }
+            }
+            registerInternalReceiver(ctx, receiver, action)
+
+            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                ctx,
+                token.hashCode(),
+                Intent(action).setPackage(ctx.packageName),
+                pendingFlags,
+            )
+
+            session.commit(pendingIntent.intentSender)
+            committed = true
+
+            val deadlineNanos = System.nanoTime() +
+                TimeUnit.SECONDS.toNanos(INSTALL_TIMEOUT_SECONDS)
+            var result = STATUS_FAILURE
+            while (System.nanoTime() < deadlineNanos) {
+                val remainingNanos = deadlineNanos - System.nanoTime()
+                if (remainingNanos <= 0L) break
+                val waitMs = minOf(
+                    INSTALL_POLL_INTERVAL_MS,
+                    TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1L),
+                )
+                if (latch.await(waitMs, TimeUnit.MILLISECONDS)) {
+                    result = resultRef.get()
+                    break
+                }
+                if (verifyInstallSucceeded(
+                        ctx,
+                        installer,
+                        sessionId,
+                        expectedPackageName,
+                        expectedVersionCode,
+                    )
+                ) {
+                    Log.d(TAG, "install detected via package presence: $expectedPackageName")
+                    result = STATUS_SUCCESS
+                    break
+                }
+            }
+            if (result == STATUS_FAILURE) {
+                result = if (verifyInstallSucceeded(
+                        ctx,
+                        installer,
+                        sessionId,
+                        expectedPackageName,
+                        expectedVersionCode,
+                    )
+                ) {
+                    Log.d(TAG, "install succeeded after timeout (package present): $expectedPackageName")
+                    STATUS_SUCCESS
+                } else if (resultRef.get() != STATUS_FAILURE) {
+                    resultRef.get()
+                } else {
+                    installError = "Install timed out"
+                    STATUS_FAILURE
+                }
+            }
+            if (result != STATUS_SUCCESS && result != STATUS_PENDING_USER_ACTION_REQUIRED) {
+                throw RemoteException(installError ?: "Install failed with code $result")
+            }
+            result
+        } catch (e: RemoteException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "installPackage exception", e)
+            throw RemoteException(e.message ?: e.javaClass.simpleName)
+        } finally {
+            if (!committed && sessionId >= 0) {
+                try {
+                    installer.abandonSession(sessionId)
+                } catch (_: Exception) {
+                }
+            }
+            try {
+                session?.close()
+            } catch (_: Exception) {
+            }
+            if (receiver != null) {
+                try {
+                    ctx.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    override fun uninstallPackage(packageName: String?): Int {
+        if (packageName.isNullOrBlank()) {
+            return STATUS_SUCCESS
+        }
+
+        Log.d(TAG, "uninstallPackage: $packageName uid=${android.os.Process.myUid()}")
+
+        val ctx = resolveContext() ?: return STATUS_FAILURE
+        val installer = ctx.packageManager.packageInstaller
+        val latch = CountDownLatch(1)
+        val resultRef = AtomicInteger(STATUS_FAILURE)
+        val token = UUID.randomUUID().toString()
+        val action = "$ACTION_UNINSTALL_RESULT.$token"
+        var receiver: BroadcastReceiver? = null
+
+        return try {
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    val status = intent.getIntExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_FAILURE,
+                    )
+                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                    Log.d(TAG, "uninstall callback status=$status message=$message pkg=$packageName")
+                    resultRef.set(
+                        if (status == PackageInstaller.STATUS_SUCCESS) STATUS_SUCCESS else STATUS_FAILURE,
+                    )
+                    latch.countDown()
+                }
+            }
+            registerInternalReceiver(ctx, receiver, action)
+
+            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                ctx,
+                token.hashCode(),
+                Intent(action).setPackage(ctx.packageName),
+                pendingFlags,
+            )
+
+            installer.uninstall(packageName, pendingIntent.intentSender)
+            val deadlineNanos = System.nanoTime() +
+                TimeUnit.SECONDS.toNanos(UNINSTALL_TIMEOUT_SECONDS)
+            while (System.nanoTime() < deadlineNanos) {
+                val remainingNanos = deadlineNanos - System.nanoTime()
+                if (remainingNanos <= 0L) break
+                val waitMs = minOf(
+                    UNINSTALL_POLL_INTERVAL_MS,
+                    TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1L),
+                )
+                if (latch.await(waitMs, TimeUnit.MILLISECONDS)) {
+                    return resultRef.get()
+                }
+                if (!isPackageInstalled(ctx, packageName)) {
+                    Log.d(TAG, "uninstall detected via package absence: $packageName")
+                    return STATUS_SUCCESS
+                }
+            }
+            if (!isPackageInstalled(ctx, packageName)) {
+                Log.d(TAG, "uninstall succeeded after timeout (package gone): $packageName")
+                STATUS_SUCCESS
+            } else {
+                resultRef.get()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "uninstallPackage exception", e)
+            STATUS_FAILURE
+        } finally {
+            if (receiver != null) {
+                try {
+                    ctx.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    override fun destroy() {}
+
+    private fun resolveContext(): Context? {
+        serviceContext?.let { ctx ->
+            return ctx.applicationContext ?: ctx
+        }
+        val app = currentApplicationOrNull()
+        if (app?.packageName == DHIZUKU_PACKAGE) {
+            return app.applicationContext ?: app
+        }
+        return null
+    }
+
+    private fun verifyInstallSucceeded(
+        ctx: Context,
+        installer: PackageInstaller,
+        sessionId: Int,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+    ): Boolean {
+        val targetPackage = expectedPackageName?.takeIf { it.isNotBlank() }
+            ?: runCatching { installer.getSessionInfo(sessionId)?.appPackageName }
+                .onFailure { Log.e(TAG, "getSessionInfo() failed during verification", it) }
+                .getOrNull()
+            ?: return false
+        val info = packageInfoOrNull(ctx, targetPackage) ?: return false
+        if (expectedVersionCode <= 0L) return true
+        val installedVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        return installedVersion >= expectedVersionCode
+    }
+
+    private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =
+        packageInfoOrNull(ctx, packageName) != null
+
+    private fun packageInfoOrNull(ctx: Context, packageName: String) = try {
+        ctx.packageManager.getPackageInfo(packageName, 0)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun currentApplicationOrNull(): Context? = try {
+        val cls = Class.forName("android.app.ActivityThread")
+        cls.getMethod("currentApplication").invoke(null) as? Context
+    } catch (e: Exception) {
+        try {
+            val cls = Class.forName("android.app.AppGlobals")
+            cls.getMethod("getInitialApplication").invoke(null) as? Context
+        } catch (_: Exception) {
+            Log.e(TAG, "Failed to obtain Application context", e)
+            null
+        }
+    }
+
+    private fun registerInternalReceiver(ctx: Context, receiver: BroadcastReceiver, action: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            ctx.registerReceiver(receiver, IntentFilter(action))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/model/InstallState.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/model/InstallState.kt
@@ -1,6 +1,6 @@
 package com.looker.droidify.installer.model
 
-enum class InstallState { Failed, Pending, Installing, Installed }
+enum class InstallState { Failed, Pending, Installing, Uninstalling, Installed }
 
 inline val InstallState.isCancellable: Boolean
     get() = this == InstallState.Pending

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -129,6 +129,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
         data class Downloading(val read: DataSize, val total: DataSize?) : Status
         data object PendingInstall : Status
         data object Installing : Status
+        data object Uninstalling : Status
     }
 
     enum class ViewType {
@@ -1112,13 +1113,12 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
     var action: Action? = null
         set(value) {
+            if (field == value) return
+            field = value
             val index = items.indexOf(Item.InstallButtonItem)
             val progressBarIndex = items.indexOf(Item.DownloadStatusItem)
-            if (index > 0 && progressBarIndex > 0) {
-                notifyItemChanged(index)
-                notifyItemChanged(progressBarIndex)
-            }
-            field = value
+            if (index >= 0) notifyItemChanged(index)
+            if (progressBarIndex >= 0) notifyItemChanged(progressBarIndex)
         }
 
     var incompatibilityReason: CharSequence? = null
@@ -1132,11 +1132,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
     var status: Status = Status.Idle
         set(value) {
-            if (field != value) {
-                val index = items.indexOf(Item.DownloadStatusItem)
-                if (index > 0) notifyItemChanged(index)
-            }
+            if (field == value) return
             field = value
+            val index = items.indexOf(Item.DownloadStatusItem)
+            if (index >= 0) notifyItemChanged(index)
         }
 
     override val viewTypeClass: Class<ViewType>
@@ -1431,6 +1430,11 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
                         Status.Installing -> {
                             holder.statusText.setText(stringRes.installing)
+                            holder.progress.isIndeterminate = true
+                        }
+
+                        Status.Uninstalling -> {
+                            holder.statusText.setText(stringRes.uninstalling)
                             holder.progress.isIndeterminate = true
                         }
 

--- a/app/src/main/kotlin/com/looker/droidify/utility/notifications/InstallNotification.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/notifications/InstallNotification.kt
@@ -71,6 +71,13 @@ fun Context.createInstallNotification(
                             appName
                     }
 
+                    InstallState.Uninstalling -> {
+                        setSmallIcon(R.drawable.ic_delete)
+                        setProgress(-1, -1, true)
+                        getString(R.string.uninstalling) to
+                            appName
+                    }
+
                     InstallState.Installed -> {
                         setTimeoutAfter(SUCCESS_TIMEOUT)
                         setSmallIcon(R.drawable.ic_check)

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="session_installer">Session installer</string>
     <string name="root_installer">Root installer</string>
     <string name="shizuku_installer">Shizuku/Sui installer</string>
+    <string name="dhizuku_installer">Dhizuku installer</string>
     <string name="shizuku_legacy_installer">Shizuku/Sui legacy installer</string>
     <string name="shizuku_not_alive">Shizuku/Sui isn\'t running</string>
     <string name="shizuku_not_installed">Shizuku/Sui isn\'t installed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="shizuku_not_installed">Shizuku/Sui isn\'t installed</string>
     <string name="installed">Installed</string>
     <string name="installing">Installing</string>
+    <string name="uninstalling">Uninstalling</string>
     <string name="installation_failed">Installation failed</string>
     <string name="installation_failed_DESC">Failed to install %s</string>
     <string name="uninstalled_application">Uninstalled</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ ktor = "3.4.1"
 libsu = "6.0.0"
 room = "2.8.4"
 shizuku = "13.0.0"
+dhizuku = "2.5.4"
 image-viewer = "1.0.1"
 junit-jupiter = "6.0.3"
 robolectric = "4.16.1"
@@ -90,6 +91,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-test = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 shizuku-api = { group = "dev.rikka.shizuku", name = "api", version.ref = "shizuku" }
 shizuku-provider = { group = "dev.rikka.shizuku", name = "provider", version.ref = "shizuku" }
+dhizuku-api = { module = "io.github.iamr0s:Dhizuku-API", version.ref = "dhizuku" }
 image-viewer = { module = "com.github.stfalcon-studio:StfalconImageViewer", version.ref = "image-viewer" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-jupiter" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }


### PR DESCRIPTION
## Summary
- Dhizuku API dependency, AIDL, manifest, ProGuard
- `DroidifyDhizukuInstallerService` (privileged-process PackageInstaller)
- `DhizukuInstallManager`, `DhizukuInstaller`, `DhizukuPermission`
- `InstallerType.DHIZUKU` + settings picker label

**PR C of 5** — replacement stack for closed #1339. Merges former PR3+PR4 (no SessionInstaller stub).

**Depends on:** #1344 (PR B) merging first. Rebase onto `main` after #1344 lands.

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] Grant Dhizuku permission; single install/uninstall (after PR E for settings UI, or via DataStore)


Made with [Cursor](https://cursor.com)