### PR TITLE
feat: Sequential awaited update-all for silent installers

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -21,7 +21,7 @@ android {
 
     defaultConfig {
         applicationId = "com.looker.droidify"
-        minSdk = 23
+        minSdk = 26
         versionName = latestVersionName
         versionCode = 710
 
@@ -97,6 +97,7 @@ android {
     }
 
     buildFeatures {
+        aidl = true
         compose = true
         viewBinding = true
         buildConfig = true
@@ -200,6 +201,7 @@ dependencies {
 
     implementation(libs.libsu.core)
     implementation(libs.bundles.shizuku)
+    implementation(libs.dhizuku.api)
 
     implementation(libs.jackson.core)
     implementation(libs.serialization)

--- a/app/proguard.pro
+++ b/app/proguard.pro
@@ -7,3 +7,19 @@
 -dontwarn kotlinx.serialization.KSerializer
 -dontwarn kotlinx.serialization.Serializable
 -dontwarn org.slf4j.impl.StaticLoggerBinder
+
+# Dhizuku UserService — class name is passed via ComponentName; R8 must not rename it.
+-keep class com.looker.droidify.installer.installers.dhizuku.DroidifyDhizukuInstallerService { *; }
+-keepclassmembers class com.looker.droidify.installer.installers.dhizuku.DroidifyDhizukuInstallerService {
+    <init>(android.content.Context);
+    <init>();
+}
+
+# AIDL-generated Stub/Proxy classes for IPC between app and Dhizuku process
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService { *; }
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService$Stub { *; }
+-keep class com.looker.droidify.installer.installers.dhizuku.IDhizukuInstallerService$Stub$Proxy { *; }
+
+# Dhizuku library internals
+-keep class com.rosan.dhizuku.** { *; }
+-dontwarn com.rosan.dhizuku.**

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -17,6 +17,7 @@
     <uses-permission
         android:name="android.permission.QUERY_ALL_PACKAGES"
         tools:ignore="QueryAllPackagesPermission" />
+    <uses-permission android:name="com.rosan.dhizuku.permission.API" />
 
     <uses-feature
         android:name="android.software.leanback"
@@ -224,5 +225,10 @@
         </receiver>
 
     </application>
+
+    <queries>
+        <package android:name="com.rosan.dhizuku" />
+        <provider android:authorities="com.rosan.dhizuku.server.provider" />
+    </queries>
 
 </manifest>

--- a/app/src/main/aidl/com/looker/droidify/installer/installers/dhizuku/IDhizukuInstallerService.aidl
+++ b/app/src/main/aidl/com/looker/droidify/installer/installers/dhizuku/IDhizukuInstallerService.aidl
@@ -1,0 +1,7 @@
+package com.looker.droidify.installer.installers.dhizuku;
+
+interface IDhizukuInstallerService {
+    int installPackage(in android.os.ParcelFileDescriptor pfd, long fileSize, String expectedPackageName, long expectedVersionCode, String installerPackageName);
+    void destroy();
+    int uninstallPackage(String packageName);
+}

--- a/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
+++ b/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsScreen.kt
@@ -482,6 +482,7 @@ private fun InstallerTypeSetting(
                 InstallerType.LEGACY -> stringResource(R.string.legacy_installer)
                 InstallerType.SESSION -> stringResource(R.string.session_installer)
                 InstallerType.SHIZUKU -> stringResource(R.string.shizuku_installer)
+                InstallerType.DHIZUKU -> stringResource(R.string.dhizuku_installer)
                 InstallerType.ROOT -> stringResource(R.string.root_installer)
             }
         },

--- a/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/compose/settings/SettingsViewModel.kt
@@ -28,6 +28,10 @@ import com.looker.droidify.installer.installers.isMagiskGranted
 import com.looker.droidify.installer.installers.isShizukuAlive
 import com.looker.droidify.installer.installers.isShizukuGranted
 import com.looker.droidify.installer.installers.isShizukuInstalled
+import com.looker.droidify.installer.installers.dhizuku.isDhizukuAlive
+import com.looker.droidify.installer.installers.dhizuku.isDhizukuGranted
+import com.looker.droidify.installer.installers.dhizuku.isDhizukuInstalled
+import com.looker.droidify.installer.installers.dhizuku.requestDhizukuPermission
 import com.looker.droidify.installer.installers.requestPermissionListener
 import com.looker.droidify.utility.common.extension.asStateFlow
 import com.looker.droidify.utility.common.extension.updateAsMutable
@@ -150,6 +154,7 @@ class SettingsViewModel @Inject constructor(
         viewModelScope.launch {
             when (installerType) {
                 InstallerType.SHIZUKU -> handleShizukuInstaller(context, installerType)
+                InstallerType.DHIZUKU -> handleDhizukuInstaller(context, installerType)
                 InstallerType.ROOT -> handleRootInstaller(installerType)
                 InstallerType.LEGACY -> {
                     settingsRepository.setDeleteApkOnInstall(false)
@@ -173,6 +178,23 @@ class SettingsViewModel @Inject constructor(
             }
         } else {
             showSnackbar(R.string.shizuku_not_installed)
+        }
+    }
+
+
+    private suspend fun handleDhizukuInstaller(context: Context, installerType: InstallerType) {
+        if (isDhizukuInstalled(context)) {
+            when {
+                !isDhizukuAlive(context) -> showSnackbar(R.string.dhizuku_not_alive)
+                isDhizukuGranted() -> settingsRepository.setInstallerType(installerType)
+                else -> {
+                    if (requestDhizukuPermission(context)) {
+                        settingsRepository.setInstallerType(installerType)
+                    }
+                }
+            }
+        } else {
+            showSnackbar(R.string.dhizuku_not_installed)
         }
     }
 

--- a/app/src/main/kotlin/com/looker/droidify/datastore/model/InstallerType.kt
+++ b/app/src/main/kotlin/com/looker/droidify/datastore/model/InstallerType.kt
@@ -6,6 +6,7 @@ enum class InstallerType {
     LEGACY,
     SESSION,
     SHIZUKU,
+    DHIZUKU,
     ROOT,
     ;
 

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -1,6 +1,7 @@
 package com.looker.droidify.installer
 
 import android.content.Context
+import android.util.Log
 import com.looker.droidify.data.model.PackageName
 import com.looker.droidify.database.Database
 import com.looker.droidify.datastore.SettingsRepository
@@ -16,14 +17,16 @@ import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.service.SyncService
 import com.looker.droidify.utility.common.Constants
 import com.looker.droidify.utility.common.cache.Cache
-import com.looker.droidify.utility.common.extension.addAndCompute
-import com.looker.droidify.utility.common.extension.filter
+import com.looker.droidify.utility.common.extension.getPackageInfoCompat
 import com.looker.droidify.utility.common.extension.notificationManager
 import com.looker.droidify.utility.common.extension.updateAsMutable
+import com.looker.droidify.utility.common.log
+import com.looker.droidify.utility.extension.toInstalledItem
 import com.looker.droidify.utility.notifications.createInstallNotification
 import com.looker.droidify.utility.notifications.installNotification
 import com.looker.droidify.utility.notifications.removeInstallNotification
 import com.looker.droidify.utility.notifications.updatesAvailableNotification
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.consumeEach
@@ -32,17 +35,20 @@ import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import java.util.concurrent.ConcurrentHashMap
 
 class InstallManager(
     private val context: Context,
     private val settingsRepository: SettingsRepository,
 ) {
 
-    private val installItems = Channel<InstallItem>()
-    private val uninstallItems = Channel<PackageName>()
+    private val installItems = Channel<InstallItem>(Channel.UNLIMITED)
+    private val uninstallItems = Channel<PackageName>(Channel.UNLIMITED)
+    private val installCompletions = ConcurrentHashMap<String, CompletableDeferred<InstallState>>()
 
     val state = MutableStateFlow<Map<PackageName, InstallState>>(emptyMap())
 
@@ -75,6 +81,18 @@ class InstallManager(
         installItems.send(installItem)
     }
 
+    suspend fun installAndAwait(installItem: InstallItem): InstallState {
+        val key = installItem.packageName.name
+        installCompletions[key]?.let { inFlight ->
+            log("Joining in-flight install: $key", TAG)
+            return inFlight.await()
+        }
+        val deferred = CompletableDeferred<InstallState>()
+        installCompletions[key] = deferred
+        installItems.send(installItem)
+        return deferred.await()
+    }
+
     suspend infix fun uninstall(packageName: PackageName) {
         uninstallItems.send(packageName)
     }
@@ -92,55 +110,92 @@ class InstallManager(
     }
 
     private fun CoroutineScope.installer() = launch {
-        val currentQueue = mutableSetOf<String>()
-        installItems.filter { item ->
-            currentQueue.addAndCompute(item.packageName.name) { isAdded ->
-                if (isAdded) {
-                    updateState { put(item.packageName, InstallState.Pending) }
-                }
-            }
-        }.consumeEach { item ->
-            if (state.value.containsKey(item.packageName)) {
+        installItems.consumeEach { item ->
+            val key = item.packageName.name
+            log("Install started: $key", TAG)
+            val result = try {
                 updateState { put(item.packageName, InstallState.Installing) }
                 notificationManager?.installNotification(
-                    packageName = item.packageName.name,
+                    packageName = key,
                     notification = context.createInstallNotification(
-                        appName = item.packageName.name,
+                        appName = key,
                         state = InstallState.Installing,
                     ),
                 )
-                val result = installer.use { it.install(item) }
-                if (result == InstallState.Installed && installer !is LegacyInstaller) {
-                    if (deleteApkPreference.first()) {
-                        val apkFile = Cache.getReleaseFile(context, item.installFileName)
-                        apkFile.delete()
+                try {
+                    installer.use { it.install(item) }
+                } catch (e: Exception) {
+                    log("Install failed: $key — ${e.message}", TAG, Log.ERROR)
+                    InstallState.Failed
+                }.also { installResult ->
+                    notificationManager?.removeInstallNotification(key)
+                    if (installResult == InstallState.Installed) {
+                        updateState { remove(item.packageName) }
+                        log("Install succeeded: $key", TAG)
+                        if (installer !is LegacyInstaller) {
+                            refreshInstalledPackage(key)
+                            if (deleteApkPreference.first() && !SyncService.autoUpdating) {
+                                Cache.getReleaseFile(context, item.installFileName).delete()
+                            }
+                        }
+                        if (SyncService.autoUpdating) {
+                            val updates = Database.ProductAdapter.getUpdates(skipSignature.first())
+                            when {
+                                updates.isEmpty() -> {
+                                    SyncService.autoUpdating = false
+                                    notificationManager?.cancel(Constants.NOTIFICATION_ID_UPDATES)
+                                    log("Update-all batch complete", TAG)
+                                }
+                                updates.map { it.packageName } != SyncService.autoUpdateStartedFor -> {
+                                    notificationManager?.notify(
+                                        Constants.NOTIFICATION_ID_UPDATES,
+                                        updatesAvailableNotification(context, updates),
+                                    )
+                                }
+                            }
+                        }
+                    } else {
+                        updateState { put(item.packageName, installResult) }
+                        log("Install finished with $installResult: $key", TAG, Log.WARN)
                     }
                 }
-                if (result == InstallState.Installed && SyncService.autoUpdating) {
-                    val updates = Database.ProductAdapter.getUpdates(skipSignature.first())
-                    when {
-                        updates.isEmpty() -> {
-                            SyncService.autoUpdating = false
-                            notificationManager?.cancel(Constants.NOTIFICATION_ID_UPDATES)
-                        }
-                        updates.map { it.packageName } != SyncService.autoUpdateStartedFor -> {
-                            notificationManager?.notify(
-                                Constants.NOTIFICATION_ID_UPDATES,
-                                updatesAvailableNotification(context, updates),
-                            )
-                        }
-                    }
-                }
-                notificationManager?.removeInstallNotification(item.packageName.name)
-                updateState { put(item.packageName, result) }
-                currentQueue.remove(item.packageName.name)
+            } catch (e: Exception) {
+                log("Install queue error: $key — ${e.message}", TAG, Log.ERROR)
+                InstallState.Failed
             }
+            installCompletions.remove(key)?.complete(result)
         }
     }
 
     private fun CoroutineScope.uninstaller() = launch {
-        uninstallItems.consumeEach {
-            installer.uninstall(it)
+        uninstallItems.consumeEach { packageName ->
+            val key = packageName.name
+            log("Uninstall queued: $key", TAG)
+            updateState { put(packageName, InstallState.Uninstalling) }
+            try {
+                log("Uninstall started: $key", TAG)
+                notificationManager?.installNotification(
+                    packageName = key,
+                    notification = context.createInstallNotification(
+                        appName = key,
+                        state = InstallState.Uninstalling,
+                    ),
+                )
+                try {
+                    installer.uninstall(packageName)
+                } catch (e: Exception) {
+                    log("Uninstall failed: $key — ${e.message}", TAG, Log.ERROR)
+                    throw e
+                }
+                notificationManager?.removeInstallNotification(key)
+                updateState { remove(packageName) }
+                refreshUninstalledPackage(key)
+                log("Uninstall succeeded: $key", TAG)
+            } catch (e: Exception) {
+                log("Uninstall error (cleanup): $key — ${e.message}", TAG, Log.ERROR)
+                notificationManager?.removeInstallNotification(key)
+                updateState { remove(packageName) }
+            }
         }
     }
 
@@ -157,5 +212,40 @@ class InstallManager(
 
     private inline fun updateState(block: MutableMap<PackageName, InstallState>.() -> Unit) {
         state.update { it.updateAsMutable(block) }
+    }
+
+    /**
+     * Silent installers (Session/Shizuku/Dhizuku) may not deliver [Intent.ACTION_PACKAGE_ADDED]
+     * to our dynamic receiver when install runs in another UID. Refresh the local DB explicitly.
+     */
+    private suspend fun refreshInstalledPackage(packageName: String) {
+        repeat(REFRESH_INSTALLED_ATTEMPTS) { attempt ->
+            val packageInfo = context.packageManager.getPackageInfoCompat(packageName)
+            if (packageInfo != null) {
+                Database.InstalledAdapter.put(packageInfo.toInstalledItem())
+                return
+            }
+            if (attempt < REFRESH_INSTALLED_ATTEMPTS - 1) {
+                delay(REFRESH_INSTALLED_DELAY_MS)
+            }
+        }
+    }
+
+    private suspend fun refreshUninstalledPackage(packageName: String) {
+        repeat(REFRESH_INSTALLED_ATTEMPTS) { attempt ->
+            if (context.packageManager.getPackageInfoCompat(packageName) == null) {
+                Database.InstalledAdapter.delete(packageName)
+                return
+            }
+            if (attempt < REFRESH_INSTALLED_ATTEMPTS - 1) {
+                delay(REFRESH_INSTALLED_DELAY_MS)
+            }
+        }
+    }
+
+    companion object {
+        private const val TAG = "DroidifyUpdateAll"
+        private const val REFRESH_INSTALLED_ATTEMPTS = 20
+        private const val REFRESH_INSTALLED_DELAY_MS = 250L
     }
 }

--- a/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/InstallManager.kt
@@ -12,6 +12,7 @@ import com.looker.droidify.installer.installers.LegacyInstaller
 import com.looker.droidify.installer.installers.root.RootInstaller
 import com.looker.droidify.installer.installers.session.SessionInstaller
 import com.looker.droidify.installer.installers.shizuku.ShizukuInstaller
+import com.looker.droidify.installer.installers.dhizuku.DhizukuInstaller
 import com.looker.droidify.installer.model.InstallItem
 import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.service.SyncService
@@ -205,6 +206,7 @@ class InstallManager(
                 InstallerType.LEGACY -> LegacyInstaller(context, settingsRepository)
                 InstallerType.SESSION -> SessionInstaller(context)
                 InstallerType.SHIZUKU -> ShizukuInstaller(context)
+                InstallerType.DHIZUKU -> DhizukuInstaller(context)
                 InstallerType.ROOT -> RootInstaller(context)
             }
         }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstallManager.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstallManager.kt
@@ -1,0 +1,390 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.ServiceConnection
+import android.content.pm.PackageManager
+import android.os.DeadObjectException
+import android.os.IBinder
+import android.os.ParcelFileDescriptor
+import android.os.RemoteException
+import android.util.Log
+import com.rosan.dhizuku.api.Dhizuku
+import com.rosan.dhizuku.api.DhizukuUserServiceArgs
+import java.io.File
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+
+class DhizukuInstallManager(private val context: Context) {
+    private val bindLock = Any()
+
+    @Volatile
+    private var installerService: IDhizukuInstallerService? = null
+
+    @Volatile
+    private var serviceConnection: ServiceConnection? = null
+
+    fun installApk(apkPath: String) {
+        if (!Dhizuku.init(context)) {
+            throw IllegalStateException("Dhizuku is not available")
+        }
+        if (!Dhizuku.isPermissionGranted()) {
+            throw SecurityException("Dhizuku permission denied")
+        }
+
+        val file = File(apkPath)
+        if (!file.exists() || file.length() <= 0L) {
+            throw IllegalArgumentException("APK file missing or empty")
+        }
+
+        var lastError: Exception? = null
+        repeat(MAX_INSTALL_ATTEMPTS) { attempt ->
+            if (attempt > 0) {
+                Log.w(TAG, "Retrying Dhizuku install after rebinding (attempt ${attempt + 1})")
+                synchronized(dhizukuOperationLock) {
+                    resetUserServiceState()
+                }
+            }
+
+            try {
+                val service = bindInstallerService(clearCache = attempt == 0)
+                    ?: throw IllegalStateException("Failed to bind Dhizuku installer service")
+                performInstall(service, file)
+                return
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt == MAX_INSTALL_ATTEMPTS - 1 || !shouldRetryBind(e)) {
+                    throw e
+                }
+                if (isDhizukuStartupError(e)) {
+                    launchDhizuku(context)
+                    Thread.sleep(DHIZUKU_STARTUP_SETTLE_MS)
+                }
+                Log.w(TAG, "Dhizuku install failed, will rebind: ${e.message}")
+            }
+        }
+
+        throw lastError ?: IllegalStateException("Dhizuku install failed")
+    }
+
+    fun uninstallPackage(packageName: String) {
+        if (!Dhizuku.init(context)) {
+            throw IllegalStateException("Dhizuku is not available")
+        }
+        if (!Dhizuku.isPermissionGranted()) {
+            throw SecurityException("Dhizuku permission denied")
+        }
+
+        var lastError: Exception? = null
+        repeat(MAX_INSTALL_ATTEMPTS) { attempt ->
+            if (attempt > 0) {
+                Log.w(TAG, "Retrying Dhizuku uninstall after rebinding (attempt ${attempt + 1})")
+                synchronized(dhizukuOperationLock) {
+                    resetUserServiceState()
+                }
+            }
+
+            try {
+                val service = bindInstallerService(clearCache = attempt == 0)
+                    ?: throw IllegalStateException("Failed to bind Dhizuku installer service")
+                val result = service.uninstallPackage(packageName)
+                if (result == DroidifyDhizukuInstallerService.STATUS_SUCCESS) {
+                    return
+                }
+                throw IllegalStateException("Uninstall failed with code $result")
+            } catch (e: Exception) {
+                lastError = e
+                if (attempt == MAX_INSTALL_ATTEMPTS - 1 || !shouldRetryBind(e)) {
+                    throw e
+                }
+                if (isDhizukuStartupError(e)) {
+                    launchDhizuku(context)
+                    Thread.sleep(DHIZUKU_STARTUP_SETTLE_MS)
+                }
+                Log.w(TAG, "Dhizuku uninstall failed, will rebind: ${e.message}")
+            }
+        }
+
+        throw lastError ?: IllegalStateException("Dhizuku uninstall failed")
+    }
+
+    /** Bind only — remote install/uninstall RPC runs outside the lock so ops can overlap. */
+    private fun bindInstallerService(clearCache: Boolean): IDhizukuInstallerService? =
+        synchronized(dhizukuOperationLock) {
+            if (clearCache) {
+                clearStaleDhizukuClientCache(userServiceArgs())
+            }
+            getOrBindService()
+        }
+
+    private fun performInstall(service: IDhizukuInstallerService, file: File) {
+        val (expectedPackageName, expectedVersionCode) = readApkIdentity(file.absolutePath)
+        var result = openAndInstall(
+            service,
+            file,
+            expectedPackageName,
+            expectedVersionCode,
+            null,
+        )
+
+        if (result == DroidifyDhizukuInstallerService.STATUS_PENDING_USER_ACTION_REQUIRED) {
+            result = openAndInstall(
+                service,
+                file,
+                expectedPackageName,
+                expectedVersionCode,
+                context.packageName,
+            )
+        }
+
+        when (result) {
+            DroidifyDhizukuInstallerService.STATUS_SUCCESS -> Unit
+            DroidifyDhizukuInstallerService.STATUS_PENDING_USER_ACTION_REQUIRED ->
+                throw IllegalStateException("Install requires user action")
+            else -> throw IllegalStateException("Install failed with code $result")
+        }
+    }
+
+    private fun openAndInstall(
+        service: IDhizukuInstallerService,
+        file: File,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+    ): Int {
+        try {
+            return ParcelFileDescriptor.open(file, ParcelFileDescriptor.MODE_READ_ONLY).use { pfd ->
+                service.installPackage(
+                    pfd,
+                    file.length(),
+                    expectedPackageName,
+                    expectedVersionCode,
+                    installerPackageName,
+                )
+            }
+        } catch (e: RemoteException) {
+            throw IllegalStateException(formatRemoteError(e), e)
+        } catch (e: DeadObjectException) {
+            throw IllegalStateException("Dhizuku installer service disconnected", e)
+        }
+    }
+
+    private fun getOrBindService(): IDhizukuInstallerService? {
+        synchronized(bindLock) {
+            installerService?.let { service ->
+                val alive = try {
+                    service.asBinder().pingBinder()
+                } catch (_: Exception) {
+                    false
+                }
+                if (alive) {
+                    return service
+                }
+                invalidateServiceLocked()
+                clearStaleDhizukuClientCache(userServiceArgs())
+                stopUserServiceQuietly()
+            }
+        }
+        return bindServiceSync()
+    }
+
+    private fun userServiceArgs(): DhizukuUserServiceArgs {
+        val componentName = ComponentName(
+            context.packageName,
+            DroidifyDhizukuInstallerService::class.java.name,
+        )
+        return DhizukuUserServiceArgs(componentName)
+    }
+
+    private fun invalidateServiceLocked() {
+        val conn = serviceConnection
+        installerService = null
+        serviceConnection = null
+        if (conn != null) {
+            try {
+                Dhizuku.unbindUserService(conn)
+            } catch (e: Exception) {
+                Log.w(TAG, "unbindUserService failed: ${e.message}")
+            }
+        }
+    }
+
+    private fun resetUserServiceState() {
+        invalidateServiceLocked()
+        clearStaleDhizukuClientCache(userServiceArgs())
+        stopUserServiceQuietly()
+    }
+
+    private fun stopUserServiceQuietly() {
+        try {
+            Dhizuku.stopUserService(userServiceArgs())
+            Thread.sleep(STOP_SETTLE_MS)
+        } catch (e: Exception) {
+            Log.w(TAG, "stopUserService failed: ${e.message}")
+        }
+    }
+
+    private fun clearStaleDhizukuClientCache(args: DhizukuUserServiceArgs) {
+        try {
+            val clazz = Class.forName("com.rosan.dhizuku.api.DhizukuServiceConnections")
+            val servicesField = clazz.getDeclaredField("services")
+            servicesField.isAccessible = true
+            @Suppress("UNCHECKED_CAST")
+            val services = servicesField.get(null) as MutableMap<String, IBinder>
+            val token = args.componentName.flattenToString()
+            if (services.remove(token) != null) {
+                Log.d(TAG, "Cleared stale Dhizuku client binder cache for $token")
+            }
+        } catch (e: Exception) {
+            Log.w(TAG, "Failed to clear Dhizuku client cache: ${e.message}")
+        }
+    }
+
+    private fun isBinderAlive(binder: IBinder?): Boolean {
+        if (binder == null) return false
+        return try {
+            binder.pingBinder()
+        } catch (_: Exception) {
+            false
+        }
+    }
+
+    private fun bindServiceSync(attempt: Int = 0): IDhizukuInstallerService? {
+        if (attempt >= MAX_BIND_ATTEMPTS) {
+            Log.e(TAG, "Exceeded max bind attempts ($MAX_BIND_ATTEMPTS)")
+            return null
+        }
+
+        if (attempt > 0) {
+            clearStaleDhizukuClientCache(userServiceArgs())
+            Thread.sleep(BIND_RETRY_DELAY_MS * attempt)
+            if (attempt >= 2) {
+                stopUserServiceQuietly()
+            }
+        }
+
+        val args = userServiceArgs()
+        val latch = CountDownLatch(1)
+        var boundService: IDhizukuInstallerService? = null
+        var disconnectedDuringBind = false
+
+        val connection = object : ServiceConnection {
+            override fun onServiceConnected(name: ComponentName?, binder: IBinder?) {
+                val alive = isBinderAlive(binder)
+                if (!alive) {
+                    clearStaleDhizukuClientCache(args)
+                    return
+                }
+                boundService = IDhizukuInstallerService.Stub.asInterface(binder)
+                synchronized(bindLock) {
+                    installerService = boundService
+                    serviceConnection = this
+                }
+                latch.countDown()
+            }
+
+            override fun onServiceDisconnected(name: ComponentName?) {
+                disconnectedDuringBind = true
+                synchronized(bindLock) {
+                    installerService = null
+                    serviceConnection = null
+                }
+                latch.countDown()
+            }
+        }
+
+        val bound = Dhizuku.bindUserService(args, connection)
+        if (!bound) {
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            return bindServiceSync(attempt + 1)
+        }
+
+        val connected = latch.await(BIND_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+        if (!connected) {
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            clearStaleDhizukuClientCache(args)
+            return bindServiceSync(attempt + 1)
+        }
+
+        val service = boundService
+        val aliveAfterBind = service != null && isBinderAlive(service.asBinder())
+        if (!aliveAfterBind || disconnectedDuringBind) {
+            synchronized(bindLock) {
+                installerService = null
+                serviceConnection = null
+            }
+            try {
+                Dhizuku.unbindUserService(connection)
+            } catch (_: Exception) {
+            }
+            clearStaleDhizukuClientCache(args)
+            return bindServiceSync(attempt + 1)
+        }
+
+        return service
+    }
+
+    private fun readApkIdentity(apkPath: String): Pair<String?, Long> {
+        val info = context.packageManager.getPackageArchiveInfo(
+            apkPath,
+            PackageManager.GET_ACTIVITIES,
+        ) ?: return null to -1L
+        info.applicationInfo?.apply {
+            sourceDir = apkPath
+            publicSourceDir = apkPath
+        }
+        val versionCode = if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        return info.packageName to versionCode
+    }
+
+    private fun shouldRetryBind(error: Exception): Boolean {
+        if (error is DeadObjectException) return true
+        if (error.cause is DeadObjectException || error.cause is RemoteException) return true
+        return isDhizukuStartupError(error)
+    }
+
+    private fun isDhizukuStartupError(error: Exception): Boolean {
+        val message = buildString {
+            append(error.message.orEmpty())
+            error.cause?.message?.let { append(' ').append(it) }
+        }
+        return message.contains("disconnect", ignoreCase = true) ||
+            message.contains("binder", ignoreCase = true) ||
+            message.contains("connection", ignoreCase = true) ||
+            message.contains("DeadObject", ignoreCase = true) ||
+            message.contains("Failed to bind", ignoreCase = true) ||
+            message.contains("remote call failed", ignoreCase = true) ||
+            message.contains("does not belong", ignoreCase = true) ||
+            message.contains("frozen", ignoreCase = true) ||
+            message.contains("No definition found", ignoreCase = true) ||
+            message.contains("Modules configuration", ignoreCase = true)
+    }
+
+    private fun formatRemoteError(error: RemoteException): String {
+        return error.message?.takeIf { it.isNotBlank() }
+            ?: error.cause?.message?.takeIf { it.isNotBlank() }
+            ?: "Dhizuku installer remote call failed"
+    }
+
+    companion object {
+        private val dhizukuOperationLock = Any()
+        private const val TAG = "DhizukuInstallManager"
+        private const val BIND_TIMEOUT_SECONDS = 15L
+        private const val MAX_INSTALL_ATTEMPTS = 3
+        private const val MAX_BIND_ATTEMPTS = 3
+        private const val STOP_SETTLE_MS = 400L
+        private const val BIND_RETRY_DELAY_MS = 500L
+        private const val DHIZUKU_STARTUP_SETTLE_MS = 1500L
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuInstaller.kt
@@ -1,0 +1,55 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.Context
+import android.util.Log
+import com.looker.droidify.data.model.PackageName
+import com.looker.droidify.installer.installers.Installer
+import com.looker.droidify.installer.model.InstallItem
+import com.looker.droidify.installer.model.InstallState
+import com.looker.droidify.utility.common.cache.Cache
+import com.looker.droidify.utility.common.extension.getPackageInfoCompat
+import com.looker.droidify.utility.common.extension.size
+import kotlinx.coroutines.delay
+
+class DhizukuInstaller(private val context: Context) : Installer {
+
+    private val installManager = DhizukuInstallManager(context)
+
+    override suspend fun install(installItem: InstallItem): InstallState {
+        val file = Cache.getReleaseFile(context, installItem.installFileName)
+        if (file.length() == 0L) {
+            error("File is not valid: Size ${file.size}")
+        }
+        if (!ensureDhizukuInstallerReady(context)) {
+            Log.e(TAG, "Dhizuku not ready for ${installItem.packageName.name}")
+            return InstallState.Failed
+        }
+        return try {
+            installManager.installApk(file.absolutePath)
+            awaitPackageVisible(installItem.packageName.name)
+            InstallState.Installed
+        } catch (e: Exception) {
+            Log.e(TAG, "Dhizuku install failed: ${installItem.packageName.name}", e)
+            InstallState.Failed
+        }
+    }
+
+    private suspend fun awaitPackageVisible(packageName: String) {
+        repeat(PACKAGE_VISIBLE_ATTEMPTS) {
+            if (context.packageManager.getPackageInfoCompat(packageName) != null) return
+            delay(PACKAGE_VISIBLE_DELAY_MS)
+        }
+    }
+
+    override suspend fun uninstall(packageName: PackageName) {
+        installManager.uninstallPackage(packageName.name)
+    }
+
+    override fun close() = Unit
+
+    companion object {
+        private const val TAG = "DhizukuInstaller"
+        private const val PACKAGE_VISIBLE_ATTEMPTS = 20
+        private const val PACKAGE_VISIBLE_DELAY_MS = 250L
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -22,8 +22,15 @@ fun isDhizukuInstalled(context: Context): Boolean =
         false
     }
 
+/**
+ * True when a Dhizuku-compatible server is reachable. [Dhizuku.init] resolves the server from the
+ * active device owner's provider rather than a fixed package, so this also matches third-party
+ * servers such as OwnDroid's built-in Dhizuku server — not only the standalone Dhizuku app. Gating
+ * this on [isDhizukuInstalled] (a hardcoded `com.rosan.dhizuku` lookup) would reject those servers
+ * even when they are running, so the install check is intentionally left out here.
+ */
 fun isDhizukuAlive(context: Context): Boolean =
-    isDhizukuInstalled(context) && try {
+    try {
         Dhizuku.init(context)
     } catch (_: Exception) {
         false

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -1,0 +1,116 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.content.ComponentName
+import android.content.Context
+import android.content.Intent
+import android.content.pm.PackageManager
+import com.looker.droidify.utility.common.extension.getLauncherActivities
+import com.looker.droidify.utility.common.extension.intent
+import com.rosan.dhizuku.api.Dhizuku
+import com.rosan.dhizuku.api.DhizukuRequestPermissionListener
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.suspendCancellableCoroutine
+import kotlin.coroutines.resume
+
+private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
+
+fun isDhizukuInstalled(context: Context): Boolean =
+    try {
+        context.packageManager.getPackageInfo(DHIZUKU_PACKAGE, 0)
+        true
+    } catch (_: PackageManager.NameNotFoundException) {
+        false
+    }
+
+fun isDhizukuAlive(context: Context): Boolean =
+    isDhizukuInstalled(context) && try {
+        Dhizuku.init(context)
+    } catch (_: Exception) {
+        false
+    }
+
+fun isDhizukuGranted(): Boolean =
+    try {
+        Dhizuku.isPermissionGranted()
+    } catch (_: Exception) {
+        false
+    }
+
+fun launchDhizuku(context: Context) {
+    if (!isDhizukuInstalled(context)) return
+    val activities = context.packageManager.getLauncherActivities(DHIZUKU_PACKAGE)
+    if (activities.isEmpty()) return
+    val launchIntent = intent(Intent.ACTION_MAIN) {
+        addCategory(Intent.CATEGORY_LAUNCHER)
+        setComponent(
+            ComponentName(
+                DHIZUKU_PACKAGE,
+                activities.first().first,
+            ),
+        )
+        setFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+    }
+    context.startActivity(launchIntent)
+}
+
+private const val DHIZUKU_WAKE_POLL_ATTEMPTS = 15
+private const val DHIZUKU_WAKE_POLL_DELAY_MS = 200L
+private const val DHIZUKU_INSTALLER_READY_ATTEMPTS = 25
+private const val DHIZUKU_INSTALLER_STABILITY_DELAY_MS = 200L
+
+suspend fun ensureDhizukuAlive(context: Context): Boolean {
+    if (isDhizukuAlive(context)) return true
+    if (!isDhizukuInstalled(context)) return false
+    launchDhizuku(context)
+    repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
+        delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+        if (isDhizukuAlive(context)) return true
+    }
+    return false
+}
+
+/** Dhizuku server may throw while Koin is still starting after wake; poll until stable. */
+suspend fun ensureDhizukuGranted(): Boolean {
+    repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
+        if (isDhizukuGranted()) return true
+        delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+    }
+    return isDhizukuGranted()
+}
+
+/**
+ * Wake Dhizuku and wait until permission + DI are stable enough for install/uninstall RPC.
+ * Needed for update-all and other background installs where the UI does not prepare Dhizuku first.
+ */
+suspend fun ensureDhizukuInstallerReady(context: Context): Boolean {
+    if (!ensureDhizukuAlive(context)) return false
+    if (!ensureDhizukuGranted()) return false
+    repeat(DHIZUKU_INSTALLER_READY_ATTEMPTS) {
+        delay(DHIZUKU_INSTALLER_STABILITY_DELAY_MS)
+        if (!isDhizukuAlive(context)) {
+            ensureDhizukuAlive(context)
+            return@repeat
+        }
+        if (isDhizukuGranted()) return true
+    }
+    return isDhizukuAlive(context) && isDhizukuGranted()
+}
+
+suspend fun requestDhizukuPermission(context: Context): Boolean =
+    suspendCancellableCoroutine { continuation ->
+        if (!Dhizuku.init(context)) {
+            continuation.resume(false)
+            return@suspendCancellableCoroutine
+        }
+        if (isDhizukuGranted()) {
+            continuation.resume(true)
+            return@suspendCancellableCoroutine
+        }
+        Dhizuku.requestPermission(object : DhizukuRequestPermissionListener() {
+            override fun onRequestPermission(grantResult: Int) {
+                if (continuation.isActive) {
+                    continuation.resume(grantResult == PackageManager.PERMISSION_GRANTED)
+                }
+            }
+        })
+    }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DhizukuPermission.kt
@@ -4,10 +4,13 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
+import android.net.Uri
+import android.util.Log
 import com.looker.droidify.utility.common.extension.getLauncherActivities
 import com.looker.droidify.utility.common.extension.intent
 import com.rosan.dhizuku.api.Dhizuku
 import com.rosan.dhizuku.api.DhizukuRequestPermissionListener
+import com.rosan.dhizuku.shared.DhizukuVariables
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.suspendCancellableCoroutine
 import kotlin.coroutines.resume
@@ -64,13 +67,36 @@ private const val DHIZUKU_WAKE_POLL_ATTEMPTS = 15
 private const val DHIZUKU_WAKE_POLL_DELAY_MS = 200L
 private const val DHIZUKU_INSTALLER_READY_ATTEMPTS = 25
 private const val DHIZUKU_INSTALLER_STABILITY_DELAY_MS = 200L
+private const val TAG = "DhizukuPermission"
+
+/**
+ * Gracefully unfreezes the Dhizuku server process. Built-in servers such as OwnDroid keep no
+ * foreground service, so the process is frozen once backgrounded and the first bind returns
+ * "error -74 (sent to frozen apps)". A *real* ContentProvider transaction is AMS-mediated and
+ * unfreezes the target — unlike acquiring the client alone or a raw binder call. Best-effort; the
+ * result is irrelevant, delivering the call is what forces the unfreeze. Callers still poll after.
+ */
+fun wakeDhizukuServer(context: Context) {
+    runCatching {
+        val authority = DhizukuVariables.getProviderAuthorityName(Dhizuku.getOwnerPackageName())
+        val uri = Uri.parse("content://$authority")
+        context.contentResolver.acquireUnstableContentProviderClient(uri)?.use { client ->
+            runCatching { client.call("ping", null, null) }
+        }
+    }.onFailure { Log.w(TAG, "wakeDhizukuServer failed: ${it.message}") }
+}
 
 suspend fun ensureDhizukuAlive(context: Context): Boolean {
     if (isDhizukuAlive(context)) return true
-    if (!isDhizukuInstalled(context)) return false
-    launchDhizuku(context)
+    // Unfreeze a cached server (e.g. OwnDroid) without needing a launcher activity. The standalone
+    // Dhizuku app additionally needs its UI launched to start the server; built-in servers have no
+    // launcher and simply no-op here. Either way, poll until the server answers — and keep waking
+    // it each round, since it can be re-frozen between attempts.
+    wakeDhizukuServer(context)
+    if (isDhizukuInstalled(context)) launchDhizuku(context)
     repeat(DHIZUKU_WAKE_POLL_ATTEMPTS) {
         delay(DHIZUKU_WAKE_POLL_DELAY_MS)
+        wakeDhizukuServer(context)
         if (isDhizukuAlive(context)) return true
     }
     return false

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
@@ -1,6 +1,7 @@
 package com.looker.droidify.installer.installers.dhizuku
 
 import android.app.PendingIntent
+import android.app.admin.DevicePolicyManager
 import android.content.BroadcastReceiver
 import android.content.Context
 import android.content.Intent
@@ -27,7 +28,6 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
         const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
 
         private const val TAG = "DroidifyDhizuku"
-        private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
         private const val INSTALL_TIMEOUT_SECONDS = 120L
         private const val UNINSTALL_TIMEOUT_SECONDS = 30L
         private const val INSTALL_POLL_INTERVAL_MS = 200L
@@ -292,11 +292,12 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
         serviceContext?.let { ctx ->
             return ctx.applicationContext ?: ctx
         }
-        val app = currentApplicationOrNull()
-        if (app?.packageName == DHIZUKU_PACKAGE) {
-            return app.applicationContext ?: app
-        }
-        return null
+        // No service Context was supplied: accept the host process only if it is the active device
+        // owner. Dhizuku loads this service into the device-owner process regardless of which app
+        // provides the server (the standalone Dhizuku app, OwnDroid's built-in server, ...), so
+        // verify ownership instead of matching a hardcoded package name.
+        val app = currentApplicationOrNull() ?: return null
+        return if (isDeviceOwner(app)) app.applicationContext ?: app else null
     }
 
     private fun verifyInstallSucceeded(
@@ -320,6 +321,14 @@ class DroidifyDhizukuInstallerService @JvmOverloads constructor(
             info.versionCode.toLong()
         }
         return installedVersion >= expectedVersionCode
+    }
+
+    private fun isDeviceOwner(ctx: Context): Boolean = try {
+        val dpm = ctx.getSystemService(Context.DEVICE_POLICY_SERVICE) as? DevicePolicyManager
+        dpm?.isDeviceOwnerApp(ctx.packageName) == true
+    } catch (e: Exception) {
+        Log.w(TAG, "Device-owner check failed", e)
+        false
     }
 
     private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/dhizuku/DroidifyDhizukuInstallerService.kt
@@ -1,0 +1,355 @@
+package com.looker.droidify.installer.installers.dhizuku
+
+import android.app.PendingIntent
+import android.content.BroadcastReceiver
+import android.content.Context
+import android.content.Intent
+import android.content.IntentFilter
+import android.content.pm.PackageInstaller
+import android.os.Build
+import android.os.ParcelFileDescriptor
+import android.os.RemoteException
+import android.util.Log
+import androidx.annotation.Keep
+import java.util.UUID
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+@Keep
+class DroidifyDhizukuInstallerService @JvmOverloads constructor(
+    private val serviceContext: Context? = null,
+) : IDhizukuInstallerService.Stub() {
+
+    companion object {
+        const val STATUS_SUCCESS = 0
+        const val STATUS_FAILURE = -1
+        const val STATUS_PENDING_USER_ACTION_REQUIRED = -2
+
+        private const val TAG = "DroidifyDhizuku"
+        private const val DHIZUKU_PACKAGE = "com.rosan.dhizuku"
+        private const val INSTALL_TIMEOUT_SECONDS = 120L
+        private const val UNINSTALL_TIMEOUT_SECONDS = 30L
+        private const val INSTALL_POLL_INTERVAL_MS = 200L
+        private const val UNINSTALL_POLL_INTERVAL_MS = 200L
+        private const val ACTION_INSTALL_RESULT = "com.looker.droidify.dhizuku.INSTALL_RESULT"
+        private const val ACTION_UNINSTALL_RESULT = "com.looker.droidify.dhizuku.UNINSTALL_RESULT"
+    }
+
+    override fun installPackage(
+        pfd: ParcelFileDescriptor,
+        fileSize: Long,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+        installerPackageName: String?,
+    ): Int {
+        Log.d(
+            TAG,
+            "installPackage size=$fileSize expected=$expectedPackageName@$expectedVersionCode " +
+                "installer=$installerPackageName uid=${android.os.Process.myUid()}",
+        )
+
+        val ctx = resolveContext() ?: run {
+            Log.e(TAG, "No application context in Dhizuku process")
+            throw RemoteException("No application context in Dhizuku process")
+        }
+
+        val installer = ctx.packageManager.packageInstaller
+        val params = PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL)
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+            params.setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
+        }
+        if (fileSize > 0) {
+            params.setSize(fileSize)
+        }
+        installerPackageName?.takeIf { it.isNotBlank() }?.let { name ->
+            try {
+                params.setInstallerPackageName(name)
+            } catch (e: Exception) {
+                Log.w(TAG, "setInstallerPackageName($name) failed: ${e.message}")
+            }
+        }
+
+        var sessionId = -1
+        var session: PackageInstaller.Session? = null
+        var receiver: BroadcastReceiver? = null
+        var committed = false
+        var installError: String? = null
+        return try {
+            sessionId = installer.createSession(params)
+            Log.d(TAG, "createSession id=$sessionId pkg=${ctx.packageName}")
+            session = installer.openSession(sessionId)
+
+            session.openWrite("apk", 0, fileSize).use { out ->
+                ParcelFileDescriptor.AutoCloseInputStream(pfd).use { input ->
+                    val copied = input.copyTo(out)
+                    out.flush()
+                    session.fsync(out)
+                    Log.d(TAG, "streamed $copied bytes to session")
+                }
+            }
+
+            val latch = CountDownLatch(1)
+            val resultRef = AtomicInteger(STATUS_FAILURE)
+            val token = UUID.randomUUID().toString()
+            val action = "$ACTION_INSTALL_RESULT.$token"
+
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    val status = intent.getIntExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_FAILURE,
+                    )
+                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                    Log.d(TAG, "install callback status=$status message=$message")
+                    when (status) {
+                        PackageInstaller.STATUS_SUCCESS -> resultRef.set(STATUS_SUCCESS)
+                        PackageInstaller.STATUS_PENDING_USER_ACTION ->
+                            resultRef.set(STATUS_PENDING_USER_ACTION_REQUIRED)
+                        else -> {
+                            installError = message ?: "PackageInstaller status=$status"
+                            resultRef.set(STATUS_FAILURE)
+                        }
+                    }
+                    latch.countDown()
+                }
+            }
+            registerInternalReceiver(ctx, receiver, action)
+
+            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                ctx,
+                token.hashCode(),
+                Intent(action).setPackage(ctx.packageName),
+                pendingFlags,
+            )
+
+            session.commit(pendingIntent.intentSender)
+            committed = true
+
+            val deadlineNanos = System.nanoTime() +
+                TimeUnit.SECONDS.toNanos(INSTALL_TIMEOUT_SECONDS)
+            var result = STATUS_FAILURE
+            while (System.nanoTime() < deadlineNanos) {
+                val remainingNanos = deadlineNanos - System.nanoTime()
+                if (remainingNanos <= 0L) break
+                val waitMs = minOf(
+                    INSTALL_POLL_INTERVAL_MS,
+                    TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1L),
+                )
+                if (latch.await(waitMs, TimeUnit.MILLISECONDS)) {
+                    result = resultRef.get()
+                    break
+                }
+                if (verifyInstallSucceeded(
+                        ctx,
+                        installer,
+                        sessionId,
+                        expectedPackageName,
+                        expectedVersionCode,
+                    )
+                ) {
+                    Log.d(TAG, "install detected via package presence: $expectedPackageName")
+                    result = STATUS_SUCCESS
+                    break
+                }
+            }
+            if (result == STATUS_FAILURE) {
+                result = if (verifyInstallSucceeded(
+                        ctx,
+                        installer,
+                        sessionId,
+                        expectedPackageName,
+                        expectedVersionCode,
+                    )
+                ) {
+                    Log.d(TAG, "install succeeded after timeout (package present): $expectedPackageName")
+                    STATUS_SUCCESS
+                } else if (resultRef.get() != STATUS_FAILURE) {
+                    resultRef.get()
+                } else {
+                    installError = "Install timed out"
+                    STATUS_FAILURE
+                }
+            }
+            if (result != STATUS_SUCCESS && result != STATUS_PENDING_USER_ACTION_REQUIRED) {
+                throw RemoteException(installError ?: "Install failed with code $result")
+            }
+            result
+        } catch (e: RemoteException) {
+            throw e
+        } catch (e: Exception) {
+            Log.e(TAG, "installPackage exception", e)
+            throw RemoteException(e.message ?: e.javaClass.simpleName)
+        } finally {
+            if (!committed && sessionId >= 0) {
+                try {
+                    installer.abandonSession(sessionId)
+                } catch (_: Exception) {
+                }
+            }
+            try {
+                session?.close()
+            } catch (_: Exception) {
+            }
+            if (receiver != null) {
+                try {
+                    ctx.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    override fun uninstallPackage(packageName: String?): Int {
+        if (packageName.isNullOrBlank()) {
+            return STATUS_SUCCESS
+        }
+
+        Log.d(TAG, "uninstallPackage: $packageName uid=${android.os.Process.myUid()}")
+
+        val ctx = resolveContext() ?: return STATUS_FAILURE
+        val installer = ctx.packageManager.packageInstaller
+        val latch = CountDownLatch(1)
+        val resultRef = AtomicInteger(STATUS_FAILURE)
+        val token = UUID.randomUUID().toString()
+        val action = "$ACTION_UNINSTALL_RESULT.$token"
+        var receiver: BroadcastReceiver? = null
+
+        return try {
+            receiver = object : BroadcastReceiver() {
+                override fun onReceive(context: Context, intent: Intent) {
+                    val status = intent.getIntExtra(
+                        PackageInstaller.EXTRA_STATUS,
+                        PackageInstaller.STATUS_FAILURE,
+                    )
+                    val message = intent.getStringExtra(PackageInstaller.EXTRA_STATUS_MESSAGE)
+                    Log.d(TAG, "uninstall callback status=$status message=$message pkg=$packageName")
+                    resultRef.set(
+                        if (status == PackageInstaller.STATUS_SUCCESS) STATUS_SUCCESS else STATUS_FAILURE,
+                    )
+                    latch.countDown()
+                }
+            }
+            registerInternalReceiver(ctx, receiver, action)
+
+            val pendingFlags = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S) {
+                PendingIntent.FLAG_UPDATE_CURRENT or PendingIntent.FLAG_MUTABLE
+            } else {
+                PendingIntent.FLAG_UPDATE_CURRENT
+            }
+            val pendingIntent = PendingIntent.getBroadcast(
+                ctx,
+                token.hashCode(),
+                Intent(action).setPackage(ctx.packageName),
+                pendingFlags,
+            )
+
+            installer.uninstall(packageName, pendingIntent.intentSender)
+            val deadlineNanos = System.nanoTime() +
+                TimeUnit.SECONDS.toNanos(UNINSTALL_TIMEOUT_SECONDS)
+            while (System.nanoTime() < deadlineNanos) {
+                val remainingNanos = deadlineNanos - System.nanoTime()
+                if (remainingNanos <= 0L) break
+                val waitMs = minOf(
+                    UNINSTALL_POLL_INTERVAL_MS,
+                    TimeUnit.NANOSECONDS.toMillis(remainingNanos).coerceAtLeast(1L),
+                )
+                if (latch.await(waitMs, TimeUnit.MILLISECONDS)) {
+                    return resultRef.get()
+                }
+                if (!isPackageInstalled(ctx, packageName)) {
+                    Log.d(TAG, "uninstall detected via package absence: $packageName")
+                    return STATUS_SUCCESS
+                }
+            }
+            if (!isPackageInstalled(ctx, packageName)) {
+                Log.d(TAG, "uninstall succeeded after timeout (package gone): $packageName")
+                STATUS_SUCCESS
+            } else {
+                resultRef.get()
+            }
+        } catch (e: Exception) {
+            Log.e(TAG, "uninstallPackage exception", e)
+            STATUS_FAILURE
+        } finally {
+            if (receiver != null) {
+                try {
+                    ctx.unregisterReceiver(receiver)
+                } catch (_: Exception) {
+                }
+            }
+        }
+    }
+
+    override fun destroy() {}
+
+    private fun resolveContext(): Context? {
+        serviceContext?.let { ctx ->
+            return ctx.applicationContext ?: ctx
+        }
+        val app = currentApplicationOrNull()
+        if (app?.packageName == DHIZUKU_PACKAGE) {
+            return app.applicationContext ?: app
+        }
+        return null
+    }
+
+    private fun verifyInstallSucceeded(
+        ctx: Context,
+        installer: PackageInstaller,
+        sessionId: Int,
+        expectedPackageName: String?,
+        expectedVersionCode: Long,
+    ): Boolean {
+        val targetPackage = expectedPackageName?.takeIf { it.isNotBlank() }
+            ?: runCatching { installer.getSessionInfo(sessionId)?.appPackageName }
+                .onFailure { Log.e(TAG, "getSessionInfo() failed during verification", it) }
+                .getOrNull()
+            ?: return false
+        val info = packageInfoOrNull(ctx, targetPackage) ?: return false
+        if (expectedVersionCode <= 0L) return true
+        val installedVersion = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+            info.longVersionCode
+        } else {
+            @Suppress("DEPRECATION")
+            info.versionCode.toLong()
+        }
+        return installedVersion >= expectedVersionCode
+    }
+
+    private fun isPackageInstalled(ctx: Context, packageName: String): Boolean =
+        packageInfoOrNull(ctx, packageName) != null
+
+    private fun packageInfoOrNull(ctx: Context, packageName: String) = try {
+        ctx.packageManager.getPackageInfo(packageName, 0)
+    } catch (_: Exception) {
+        null
+    }
+
+    private fun currentApplicationOrNull(): Context? = try {
+        val cls = Class.forName("android.app.ActivityThread")
+        cls.getMethod("currentApplication").invoke(null) as? Context
+    } catch (e: Exception) {
+        try {
+            val cls = Class.forName("android.app.AppGlobals")
+            cls.getMethod("getInitialApplication").invoke(null) as? Context
+        } catch (_: Exception) {
+            Log.e(TAG, "Failed to obtain Application context", e)
+            null
+        }
+    }
+
+    private fun registerInternalReceiver(ctx: Context, receiver: BroadcastReceiver, action: String) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            ctx.registerReceiver(receiver, IntentFilter(action), Context.RECEIVER_NOT_EXPORTED)
+        } else {
+            @Suppress("UnspecifiedRegisterReceiverFlag")
+            ctx.registerReceiver(receiver, IntentFilter(action))
+        }
+    }
+}

--- a/app/src/main/kotlin/com/looker/droidify/installer/model/InstallState.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/model/InstallState.kt
@@ -1,6 +1,6 @@
 package com.looker.droidify.installer.model
 
-enum class InstallState { Failed, Pending, Installing, Installed }
+enum class InstallState { Failed, Pending, Installing, Uninstalling, Installed }
 
 inline val InstallState.isCancellable: Boolean
     get() = this == InstallState.Pending

--- a/app/src/main/kotlin/com/looker/droidify/service/DownloadService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/service/DownloadService.kt
@@ -43,8 +43,10 @@ import com.looker.droidify.utility.common.log
 import com.looker.droidify.utility.notifications.createInstallNotification
 import com.looker.droidify.utility.notifications.installNotification
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
@@ -55,14 +57,17 @@ import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.sync.Mutex
 import kotlinx.coroutines.sync.withLock
+import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
 import java.io.File
+import java.util.concurrent.ConcurrentHashMap
 import javax.inject.Inject
 import com.looker.droidify.R.string as stringRes
 
 @AndroidEntryPoint
 class DownloadService : ConnectionService<DownloadService.Binder>() {
     companion object {
+        private const val TAG = "DroidifyUpdateAll"
         private const val ACTION_CANCEL = "${BuildConfig.APPLICATION_ID}.intent.action.CANCEL"
     }
 
@@ -130,9 +135,46 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
     private var currentTask: CurrentTask? = null
 
     private val lock = Mutex()
+    private val updateCompletions = ConcurrentHashMap<String, CompletableDeferred<Boolean>>()
 
     inner class Binder : android.os.Binder() {
         val downloadState = _downloadState.asStateFlow()
+
+        suspend fun enqueueAndAwait(
+            packageName: String,
+            name: String,
+            repository: Repository,
+            release: Release,
+            isUpdate: Boolean = false,
+        ): Boolean {
+            val task = Task(
+                packageName = packageName,
+                name = name,
+                release = release,
+                url = release.getDownloadUrl(repository),
+                authentication = repository.authentication,
+                isUpdate = isUpdate,
+            )
+            val deferred = CompletableDeferred<Boolean>()
+            updateCompletions[packageName] = deferred
+            log("enqueueAndAwait: $packageName", TAG)
+            return try {
+                if (Cache.getReleaseFile(this@DownloadService, release.cacheFileName).exists()) {
+                    log("Using cached APK for $packageName (await)", TAG)
+                    publishSuccess(task)
+                } else {
+                    enqueueDownload(task)
+                }
+                withContext(NonCancellable) { deferred.await() }
+            } catch (e: Exception) {
+                log("enqueueAndAwait failed: $packageName — ${e.message}", TAG, Log.ERROR)
+                signalUpdateComplete(packageName, false)
+                false
+            } finally {
+                updateCompletions.remove(packageName)
+            }
+        }
+
         fun enqueue(
             packageName: String,
             name: String,
@@ -149,11 +191,17 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
                 isUpdate = isUpdate,
             )
             if (Cache.getReleaseFile(this@DownloadService, release.cacheFileName).exists()) {
+                log("Using cached APK for $packageName", TAG)
                 lifecycleScope.launch { publishSuccess(task) }
                 return
             }
-            cancelTasks(packageName)
-            cancelCurrentTask(packageName)
+            enqueueDownload(task)
+        }
+
+        private fun enqueueDownload(task: Task) {
+            log("Queued download for ${task.packageName} (pending=${tasks.size})", TAG)
+            cancelTasks(task.packageName)
+            cancelCurrentTask(task.packageName)
             notificationManager?.cancel(
                 task.notificationTag,
                 Constants.NOTIFICATION_ID_DOWNLOADING,
@@ -162,7 +210,7 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
             if (currentTask == null) {
                 handleDownload()
             } else {
-                updateCurrentQueue { add(packageName) }
+                updateCurrentQueue { add(task.packageName) }
             }
         }
 
@@ -298,18 +346,42 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
         val currentInstaller = installerType.first()
         updateCurrentQueue { add("") }
         updateCurrentState(State.Success(task.packageName, task.release))
+        log(
+            "Download complete: ${task.packageName}, installer=$currentInstaller, queue=${tasks.size}",
+            TAG,
+        )
         val autoInstallWithSessionInstaller =
             SdkCheck.canAutoInstall(task.release.targetSdkVersion) &&
                 currentInstaller == InstallerType.SESSION &&
                 task.isUpdate
 
         showNotificationInstall(task)
-        if (currentInstaller == InstallerType.ROOT ||
+        val success = if (currentInstaller == InstallerType.ROOT ||
             currentInstaller == InstallerType.SHIZUKU ||
+            currentInstaller == InstallerType.DHIZUKU ||
             autoInstallWithSessionInstaller
         ) {
             val installItem = task.packageName installFrom task.release.cacheFileName
-            installer install installItem
+            val result = withContext(NonCancellable) {
+                installer.installAndAwait(installItem)
+            }
+            log(
+                "Auto-install finished: ${task.packageName} -> $result",
+                TAG,
+                if (result == InstallState.Installed) Log.DEBUG else Log.WARN,
+            )
+            result == InstallState.Installed
+        } else {
+            true
+        }
+        signalUpdateComplete(task.packageName, success)
+    }
+
+    private fun signalUpdateComplete(packageName: String, success: Boolean) {
+        val pending = updateCompletions.remove(packageName)
+        if (pending != null) {
+            log("Update step complete: $packageName success=$success", TAG)
+            pending.complete(success)
         }
     }
 
@@ -436,6 +508,7 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
         task: Task,
         target: File,
     ) = launch {
+        var publishCalled = false
         try {
             val response = downloader.downloadToFile(
                 url = task.url,
@@ -458,6 +531,7 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
                         target.delete()
                         updateCurrentState(State.Error(task.packageName))
                         showErrorNotification(task, could_not_validate_FORMAT, result.message)
+                        signalUpdateComplete(task.packageName, false)
                         return@launch
                     }
                     val releaseFile = Cache.getReleaseFile(
@@ -465,6 +539,7 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
                         task.release.cacheFileName,
                     )
                     target.renameTo(releaseFile)
+                    publishCalled = true
                     publishSuccess(task)
                 }
 
@@ -478,7 +553,13 @@ class DownloadService : ConnectionService<DownloadService.Binder>() {
                         is NetworkResponse.Error.Unknown -> unknown_error_DESC
                     }
                     showErrorNotification(task, could_not_download_FORMAT, getString(description))
+                    signalUpdateComplete(task.packageName, false)
                 }
+            }
+        } catch (e: Exception) {
+            log("Download failed: ${task.packageName} — ${e.message}", TAG, Log.ERROR)
+            if (!publishCalled) {
+                signalUpdateComplete(task.packageName, false)
             }
         } finally {
             lock.withLock { currentTask = null }

--- a/app/src/main/kotlin/com/looker/droidify/service/SyncService.kt
+++ b/app/src/main/kotlin/com/looker/droidify/service/SyncService.kt
@@ -9,6 +9,7 @@ import android.content.ComponentName
 import android.content.Context
 import android.content.Intent
 import android.os.Build
+import android.util.Log
 import android.view.ContextThemeWrapper
 import androidx.core.app.NotificationCompat
 import androidx.fragment.app.Fragment
@@ -17,6 +18,8 @@ import com.looker.droidify.R
 import com.looker.droidify.database.Database
 import com.looker.droidify.datastore.Settings
 import com.looker.droidify.datastore.SettingsRepository
+import com.looker.droidify.datastore.model.InstallerType
+import com.looker.droidify.installer.installers.dhizuku.ensureDhizukuInstallerReady
 import com.looker.droidify.index.RepositoryUpdater
 import com.looker.droidify.model.ProductItem
 import com.looker.droidify.model.Repository
@@ -31,24 +34,31 @@ import com.looker.droidify.utility.common.extension.notificationManager
 import com.looker.droidify.utility.common.extension.startForegroundSafe
 import com.looker.droidify.utility.common.extension.startServiceCompat
 import com.looker.droidify.utility.common.extension.stopForegroundCompat
+import com.looker.droidify.utility.common.log
 import com.looker.droidify.utility.common.result.Result
 import com.looker.droidify.utility.common.sdkAbove
 import com.looker.droidify.utility.extension.startUpdate
+import com.looker.droidify.utility.extension.startUpdateAndAwait
 import com.looker.droidify.utility.notifications.updatesAvailableNotification
 import com.looker.droidify.work.DownloadStatsWorker
 import com.looker.droidify.work.RBLogWorker
 import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.FlowPreview
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.SharedFlow
 import kotlinx.coroutines.flow.asSharedFlow
+import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.filter
 import kotlinx.coroutines.flow.sample
+import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.sync.Mutex
@@ -66,9 +76,12 @@ import kotlinx.coroutines.Job as CoroutinesJob
 class SyncService : ConnectionService<SyncService.Binder>() {
 
     companion object {
+        private const val TAG = "DroidifyUpdateAll"
         private const val MAX_PROGRESS = 100
 
         private const val NOTIFICATION_UPDATE_SAMPLING = 400L
+        private const val DOWNLOAD_BIND_POLL_ATTEMPTS = 30
+        private const val DOWNLOAD_BIND_POLL_DELAY_MS = 100L
 
         private const val ACTION_CANCEL = "${BuildConfig.APPLICATION_ID}.intent.action.CANCEL"
 
@@ -76,6 +89,23 @@ class SyncService : ConnectionService<SyncService.Binder>() {
 
         var autoUpdating = false
         var autoUpdateStartedFor: List<String> = emptyList()
+
+        private val _updateAllProgress = MutableStateFlow(UpdateAllProgress())
+        val updateAllProgress = _updateAllProgress.asStateFlow()
+
+        fun isUpdateAllQueued(packageName: String): Boolean =
+            _updateAllProgress.value.isQueued(packageName)
+    }
+
+    data class UpdateAllProgress(
+        val batchPackages: List<String> = emptyList(),
+        val activePackage: String? = null,
+        val completedPackages: Set<String> = emptySet(),
+    ) {
+        fun isQueued(packageName: String): Boolean =
+            packageName in batchPackages &&
+                packageName !in completedPackages &&
+                packageName != activePackage
     }
 
     @Inject
@@ -122,6 +152,7 @@ class SyncService : ConnectionService<SyncService.Binder>() {
     private var currentTask: CurrentTask? = null
 
     private var updateNotificationBlockerFragment: WeakReference<Fragment>? = null
+    private var updateAllInProgress = false
 
     private val downloadConnection = Connection(DownloadService::class.java)
     private val lock = Mutex()
@@ -171,10 +202,8 @@ class SyncService : ConnectionService<SyncService.Binder>() {
             }
         }
 
-        suspend fun updateAllApps() {
-            val skipSignature = settingsRepository.getInitial().ignoreSignature
-            val updates = Database.ProductAdapter.getUpdates(skipSignature)
-            updateAllAppsInternal(updates)
+        fun updateAllApps() {
+            this@SyncService.launchUpdateAllBatch()
         }
 
         fun setUpdateNotificationBlocker(fragment: Fragment?) {
@@ -583,7 +612,9 @@ class SyncService : ConnectionService<SyncService.Binder>() {
                 if (settings.autoUpdate) {
                     autoUpdating = true
                     autoUpdateStartedFor = updates.map { it.packageName }
-                    updateAllAppsInternal(updates)
+                    withContext(NonCancellable) {
+                        updateAllAppsInternal(updates)
+                    }
                 }
             }
 
@@ -596,25 +627,140 @@ class SyncService : ConnectionService<SyncService.Binder>() {
         }
     }
 
+    private fun launchUpdateAllBatch() {
+        if (updateAllInProgress) {
+            log("Update-all already in progress, ignoring duplicate request", TAG, Log.WARN)
+            return
+        }
+        updateAllInProgress = true
+        lifecycleScope.launch {
+            try {
+                withContext(NonCancellable) {
+                    try {
+                        val skipSignature = settingsRepository.getInitial().ignoreSignature
+                        val updates = Database.ProductAdapter.getUpdates(skipSignature)
+                        autoUpdating = true
+                        autoUpdateStartedFor = updates.map { it.packageName }
+                        log("Update-all started: ${updates.size} apps — $autoUpdateStartedFor", TAG)
+                        updateAllAppsInternal(updates)
+                    } catch (e: CancellationException) {
+                        log("Update-all cancelled unexpectedly", TAG, Log.WARN)
+                        throw e
+                    } catch (e: Exception) {
+                        log("Update-all failed: ${e.message}", TAG, Log.ERROR)
+                    }
+                }
+            } finally {
+                updateAllInProgress = false
+            }
+        }
+    }
+
+    private suspend fun ensureDownloadBinder(): DownloadService.Binder? {
+        downloadConnection.binder?.let { return it }
+        log("DownloadService binder missing, re-binding", TAG, Log.WARN)
+        val intent = Intent(this@SyncService, DownloadService::class.java)
+        try {
+            if (SdkCheck.isOreo) {
+                startForegroundService(intent)
+            } else {
+                startService(intent)
+            }
+        } catch (e: Exception) {
+            log("Failed to start DownloadService: ${e.message}", TAG, Log.ERROR)
+        }
+        downloadConnection.bind(this@SyncService)
+        repeat(DOWNLOAD_BIND_POLL_ATTEMPTS) {
+            delay(DOWNLOAD_BIND_POLL_DELAY_MS)
+            downloadConnection.binder?.let { return it }
+        }
+        return downloadConnection.binder
+    }
+
     private suspend fun updateAllAppsInternal(updates: List<ProductItem>) {
-        updates
-            // Update Droid-ify the last
-            .sortedBy { if (it.packageName == packageName) 1 else -1 }
-            .map {
-                Database.InstalledAdapter.get(it.packageName, null) to
-                    Database.RepositoryAdapter.get(it.repositoryId)
+        try {
+            val settings = settingsRepository.getInitial()
+            if (ensureDownloadBinder() == null) {
+                log("Update-all aborted: DownloadService not available", TAG, Log.ERROR)
+                return
             }
-            .filter { it.first != null && it.second != null }
-            .forEach { (installItem, repo) ->
-                val productRepo = Database.ProductAdapter.get(installItem!!.packageName, null)
-                    .filter { it.repositoryId == repo!!.id }
-                    .map { it to repo!! }
-                downloadConnection.startUpdate(
-                    installItem.packageName,
-                    installItem,
-                    productRepo,
-                )
+            if (settings.installerType == InstallerType.DHIZUKU &&
+                !ensureDhizukuInstallerReady(this@SyncService)
+            ) {
+                log("Update-all aborted: Dhizuku not ready", TAG, Log.ERROR)
+                return
             }
+
+            val items = updates
+                // Update Droid-ify the last
+                .sortedBy { if (it.packageName == packageName) 1 else -1 }
+                .map {
+                    Database.InstalledAdapter.get(it.packageName, null) to
+                        Database.RepositoryAdapter.get(it.repositoryId)
+                }
+                .filter { it.first != null && it.second != null }
+
+            _updateAllProgress.value = UpdateAllProgress(
+                batchPackages = items.map { it.first!!.packageName },
+            )
+
+            for ((installItem, repo) in items) {
+                val packageName = installItem!!.packageName
+                _updateAllProgress.update { it.copy(activePackage = packageName) }
+                try {
+                    val productRepo = Database.ProductAdapter.get(packageName, null)
+                        .filter { it.repositoryId == repo!!.id }
+                        .map { it to repo!! }
+                    if (productRepo.isEmpty()) {
+                        log(
+                            "Update-all skipped $packageName: no product for repo ${repo!!.id}",
+                            TAG,
+                            Log.WARN,
+                        )
+                        continue
+                    }
+                    if (ensureDownloadBinder() == null) {
+                        log(
+                            "Update-all skipped $packageName: DownloadService not bound",
+                            TAG,
+                            Log.ERROR,
+                        )
+                        continue
+                    }
+                    if (settings.installerType == InstallerType.DHIZUKU &&
+                        !ensureDhizukuInstallerReady(this@SyncService)
+                    ) {
+                        log(
+                            "Update-all skipped $packageName: Dhizuku not ready",
+                            TAG,
+                            Log.ERROR,
+                        )
+                        continue
+                    }
+                    log("Update-all processing $packageName", TAG)
+                    val success = downloadConnection.startUpdateAndAwait(
+                        packageName,
+                        installItem,
+                        productRepo,
+                    )
+                    log(
+                        "Update-all finished $packageName: success=$success",
+                        TAG,
+                        if (success) Log.DEBUG else Log.WARN,
+                    )
+                } finally {
+                    _updateAllProgress.update {
+                        it.copy(
+                            activePackage = null,
+                            completedPackages = it.completedPackages + packageName,
+                        )
+                    }
+                }
+            }
+            log("Update-all queue drained", TAG)
+        } finally {
+            _updateAllProgress.value = UpdateAllProgress()
+        }
     }
 
     @SuppressLint("SpecifyJobSchedulerIdRange")

--- a/app/src/main/kotlin/com/looker/droidify/ui/MessageDialog.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/MessageDialog.kt
@@ -12,6 +12,7 @@ import androidx.fragment.app.DialogFragment
 import androidx.fragment.app.FragmentManager
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.looker.droidify.model.Release
+import com.looker.droidify.ui.appDetail.AppDetailFragment
 import com.looker.droidify.ui.repository.RepositoryFragment
 import com.looker.droidify.utility.PackageItemResolver
 import com.looker.droidify.utility.common.SdkCheck
@@ -48,6 +49,15 @@ class MessageDialog() : DialogFragment() {
                 dialog.setMessage(stringRes.delete_repository_DESC)
                 dialog.setPositiveButton(stringRes.delete) { _, _ ->
                     (parentFragment as RepositoryFragment).onDeleteConfirm()
+                }
+                dialog.setNegativeButton(stringRes.cancel, null)
+            }
+
+            is Message.UninstallConfirm -> {
+                dialog.setTitle(stringRes.confirmation)
+                dialog.setMessage(getString(stringRes.uninstall_application_DESC, message.appName))
+                dialog.setPositiveButton(stringRes.uninstall) { _, _ ->
+                    (parentFragment as? AppDetailFragment)?.onUninstallConfirm()
                 }
                 dialog.setNegativeButton(stringRes.cancel, null)
             }
@@ -202,6 +212,9 @@ class MessageDialog() : DialogFragment() {
 sealed interface Message : Parcelable {
     @Parcelize
     data object DeleteRepositoryConfirm : Message
+
+    @Parcelize
+    data class UninstallConfirm(val appName: String) : Message
 
     @Parcelize
     data object CantEditSyncing : Message

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailAdapter.kt
@@ -129,6 +129,7 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
         data class Downloading(val read: DataSize, val total: DataSize?) : Status
         data object PendingInstall : Status
         data object Installing : Status
+        data object Uninstalling : Status
     }
 
     enum class ViewType {
@@ -1112,13 +1113,12 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
     var action: Action? = null
         set(value) {
+            if (field == value) return
+            field = value
             val index = items.indexOf(Item.InstallButtonItem)
             val progressBarIndex = items.indexOf(Item.DownloadStatusItem)
-            if (index > 0 && progressBarIndex > 0) {
-                notifyItemChanged(index)
-                notifyItemChanged(progressBarIndex)
-            }
-            field = value
+            if (index >= 0) notifyItemChanged(index)
+            if (progressBarIndex >= 0) notifyItemChanged(progressBarIndex)
         }
 
     var incompatibilityReason: CharSequence? = null
@@ -1132,11 +1132,10 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
     var status: Status = Status.Idle
         set(value) {
-            if (field != value) {
-                val index = items.indexOf(Item.DownloadStatusItem)
-                if (index > 0) notifyItemChanged(index)
-            }
+            if (field == value) return
             field = value
+            val index = items.indexOf(Item.DownloadStatusItem)
+            if (index >= 0) notifyItemChanged(index)
         }
 
     override val viewTypeClass: Class<ViewType>
@@ -1431,6 +1430,11 @@ class AppDetailAdapter(private val callbacks: Callbacks) :
 
                         Status.Installing -> {
                             holder.statusText.setText(stringRes.installing)
+                            holder.progress.isIndeterminate = true
+                        }
+
+                        Status.Uninstalling -> {
+                            holder.statusText.setText(stringRes.uninstalling)
                             holder.progress.isIndeterminate = true
                         }
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailFragment.kt
@@ -24,7 +24,9 @@ import coil3.load
 import coil3.request.allowHardware
 import com.google.android.material.dialog.MaterialAlertDialogBuilder
 import com.looker.droidify.content.ProductPreferences
+import com.looker.droidify.datastore.model.InstallerType
 import com.looker.droidify.installer.installers.launchShizuku
+import com.looker.droidify.installer.installers.dhizuku.launchDhizuku
 import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.installer.model.isCancellable
 import com.looker.droidify.model.InstalledItem
@@ -35,6 +37,7 @@ import com.looker.droidify.model.Repository
 import com.looker.droidify.model.findSuggested
 import com.looker.droidify.service.Connection
 import com.looker.droidify.service.DownloadService
+import com.looker.droidify.service.SyncService
 import com.looker.droidify.ui.Message
 import com.looker.droidify.ui.MessageDialog
 import com.looker.droidify.ui.ScreenFragment
@@ -65,6 +68,11 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
     companion object {
         private const val STATE_LAYOUT_MANAGER = "layoutManager"
         private const val STATE_ADAPTER = "adapter"
+        private val SILENT_AUTO_INSTALLERS = setOf(
+            InstallerType.DHIZUKU,
+            InstallerType.SHIZUKU,
+            InstallerType.ROOT,
+        )
     }
 
     constructor(packageName: String, repoAddress: String? = null) : this() {
@@ -103,6 +111,13 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
     private var installed: Installed? = null
     private var downloading = false
     private var installing: InstallState? = null
+    private var autoInstallTriggeredFor: String? = null
+    private var installerType = InstallerType.Default
+
+    private val isInstallerOperationActive: Boolean
+        get() = installing == InstallState.Installing ||
+            installing == InstallState.Uninstalling ||
+            installing == InstallState.Pending
 
     private var recyclerView: RecyclerView? = null
     private var detailAdapter: AppDetailAdapter? = null
@@ -112,7 +127,7 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
         serviceClass = DownloadService::class.java,
         onBind = { _, binder ->
             lifecycleScope.launch {
-                binder.downloadState.collect(::updateDownloadState)
+                binder.downloadState.collect { refreshDownloadUi(it) }
             }
         },
     )
@@ -170,6 +185,8 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                             recyclerView?.layoutManager!!.onRestoreInstanceState(it)
                         }
                         layoutManagerState = null
+                        installerType = state.installerType
+                        val wasInstalled = installed != null
                         installed = state.installedItem?.let {
                             with(requireContext().packageManager) {
                                 val isSystem = isSystemApplication(viewModel.packageName)
@@ -180,6 +197,15 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                                 }
                                 Installed(it, isSystem, launcherActivities)
                             }
+                        }
+                        if (state.installedItem == null && wasInstalled) {
+                            installing = null
+                            downloading = false
+                            detailAdapter?.status = AppDetailAdapter.Status.Idle
+                        } else if (state.installedItem != null && installing == InstallState.Installing) {
+                            installing = null
+                            downloading = false
+                            detailAdapter?.status = AppDetailAdapter.Status.Idle
                         }
                         val adapter = recyclerView?.adapter as? AppDetailAdapter
 
@@ -209,6 +235,11 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                     viewModel.installerState.collect(::updateInstallState)
                 }
                 launch {
+                    SyncService.updateAllProgress.collect {
+                        refreshDownloadUi()
+                    }
+                }
+                launch {
                     recyclerView?.isFirstItemVisible?.collect(::updateToolbarButtons)
                 }
             }
@@ -224,6 +255,18 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
         imageViewer = null
 
         downloadConnection.unbind(requireContext())
+    }
+
+    override fun onResume() {
+        super.onResume()
+        syncOperationState()
+    }
+
+    private fun syncOperationState() {
+        updateInstallState(viewModel.installerState.value)
+        refreshDownloadUi()
+        clearStaleOperationStatus()
+        updateButtons()
     }
 
     @SuppressLint("RestrictedApi")
@@ -310,7 +353,7 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
         }
 
         val adapterAction = when {
-            installing == InstallState.Installing -> null
+            isInstallerOperationActive && installing != InstallState.Pending -> null
             installing == InstallState.Pending -> AppDetailAdapter.Action.CANCEL
             downloading -> AppDetailAdapter.Action.CANCEL
             else -> primaryAction.adapterAction
@@ -318,11 +361,13 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
 
         (recyclerView?.adapter as? AppDetailAdapter)?.action = adapterAction
 
+        val operationInProgress = downloading || isInstallerOperationActive
         for (action in sequenceOf(
             Action.INSTALL,
             Action.UPDATE,
+            Action.LAUNCH,
         )) {
-            toolbar.menu.findItem(action.id).isEnabled = !downloading
+            toolbar.menu.findItem(action.id).isEnabled = !operationInProgress
         }
         this.actions = Pair(actions, primaryAction)
         updateToolbarButtons()
@@ -352,22 +397,53 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
     }
 
     private fun updateInstallState(installerState: InstallState?) {
+        val updateAllQueued = SyncService.isUpdateAllQueued(viewModel.packageName)
         val status = when (installerState) {
             InstallState.Pending -> AppDetailAdapter.Status.PendingInstall
             InstallState.Installing -> AppDetailAdapter.Status.Installing
-            else -> AppDetailAdapter.Status.Idle
+            InstallState.Uninstalling -> AppDetailAdapter.Status.Uninstalling
+            else -> if (updateAllQueued) {
+                AppDetailAdapter.Status.Pending
+            } else {
+                AppDetailAdapter.Status.Idle
+            }
         }
         (recyclerView?.adapter as? AppDetailAdapter)?.status = status
-        installing = installerState
+        installing = when (installerState) {
+            InstallState.Pending, InstallState.Installing, InstallState.Uninstalling -> installerState
+            else -> null
+        }
+        when {
+            installing != null -> downloading = false
+            updateAllQueued -> downloading = true
+        }
         updateButtons()
     }
 
-    private fun updateDownloadState(state: DownloadService.DownloadState) {
+    private fun clearStaleOperationStatus() {
+        if (isInstallerOperationActive || downloading) return
+        if (SyncService.isUpdateAllQueued(viewModel.packageName)) return
+        when (detailAdapter?.status) {
+            AppDetailAdapter.Status.Installing,
+            AppDetailAdapter.Status.Uninstalling,
+            AppDetailAdapter.Status.PendingInstall,
+            -> detailAdapter?.status = AppDetailAdapter.Status.Idle
+            else -> Unit
+        }
+    }
+
+    private fun refreshDownloadUi(
+        state: DownloadService.DownloadState =
+            downloadConnection.binder?.downloadState?.value ?: DownloadService.DownloadState(),
+    ) {
         val packageName = viewModel.packageName
-        val isPending = packageName in state.queue
+        val updateAllQueued = SyncService.isUpdateAllQueued(packageName)
+        val isPending = packageName in state.queue || updateAllQueued
         val isDownloading = state isDownloading packageName
         val isCompleted = state isComplete packageName
-        val isActive = isPending || isDownloading
+        val downloadSucceeded = state.currentItem is DownloadService.State.Success &&
+            state.currentItem.packageName == packageName
+        val isActive = if (downloadSucceeded) false else isPending || isDownloading
         if (isPending) {
             detailAdapter?.status = AppDetailAdapter.Status.Pending
         }
@@ -382,18 +458,29 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                 else -> AppDetailAdapter.Status.Idle
             }
         }
-        if (isCompleted) {
+        if (isCompleted && !updateAllQueued) {
             detailAdapter?.status = AppDetailAdapter.Status.Idle
         }
         if (this.downloading != isActive) {
             this.downloading = isActive
             updateButtons()
         }
+        clearStaleOperationStatus()
         if (state.currentItem is DownloadService.State.Success && isResumed) {
-            viewModel.installPackage(
-                state.currentItem.packageName,
-                state.currentItem.release.cacheFileName,
-            )
+            if (installerType in SILENT_AUTO_INSTALLERS) {
+                return
+            }
+            val success = state.currentItem
+            if (success.packageName == packageName) {
+                val key = "${success.packageName}:${success.release.cacheFileName}"
+                if (autoInstallTriggeredFor != key) {
+                    autoInstallTriggeredFor = key
+                    viewModel.installPackage(
+                        success.packageName,
+                        success.release.cacheFileName,
+                    )
+                }
+            }
         }
     }
 
@@ -416,11 +503,14 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                     ).show()
                     return
                 }
-                downloadConnection.startUpdate(
-                    packageName = viewModel.packageName,
-                    installedItem = installed?.installedItem,
-                    products = products,
-                )
+
+                runAfterDhizukuReady {
+                    downloadConnection.startUpdate(
+                        packageName = viewModel.packageName,
+                        installedItem = installed?.installedItem,
+                        products = products,
+                    )
+                }
             }
 
             AppDetailAdapter.Action.LAUNCH -> {
@@ -444,7 +534,14 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                 )
             }
 
-            AppDetailAdapter.Action.UNINSTALL -> viewModel.uninstallPackage()
+            AppDetailAdapter.Action.UNINSTALL -> {
+                if (installerType == InstallerType.DHIZUKU) {
+                    val appName = products.firstOrNull()?.first?.name ?: viewModel.packageName
+                    MessageDialog(Message.UninstallConfirm(appName)).show(childFragmentManager)
+                } else {
+                    viewModel.uninstallPackage()
+                }
+            }
 
             AppDetailAdapter.Action.CANCEL -> {
                 val binder = downloadConnection.binder
@@ -479,6 +576,28 @@ class AppDetailFragment() : ScreenFragment(), AppDetailAdapter.Callbacks {
                 val link = products[0].first.source
                 context?.openLink(link)
             }
+        }
+    }
+
+    internal fun onUninstallConfirm() {
+        runAfterDhizukuReady {
+            viewModel.uninstallPackage()
+        }
+    }
+
+    private fun runAfterDhizukuReady(onReady: () -> Unit) {
+        viewLifecycleOwner.lifecycleScope.launch {
+            val dhizukuState = viewModel.prepareDhizuku(requireContext())
+            if (dhizukuState != null) {
+                dhizukuDialog(
+                    context = requireContext(),
+                    dhizukuState = dhizukuState,
+                    openDhizuku = { launchDhizuku(requireContext()) },
+                    switchInstaller = { viewModel.setDefaultInstaller() },
+                ).show()
+                return@launch
+            }
+            onReady()
         }
     }
 

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/AppDetailViewModel.kt
@@ -18,7 +18,9 @@ import com.looker.droidify.installer.installers.isShizukuAlive
 import com.looker.droidify.installer.installers.isShizukuGranted
 import com.looker.droidify.installer.installers.isShizukuInstalled
 import com.looker.droidify.installer.installers.isSuiAvailable
-import com.looker.droidify.installer.installers.requestPermissionListener
+import com.looker.droidify.installer.installers.dhizuku.ensureDhizukuInstallerReady
+import com.looker.droidify.installer.installers.dhizuku.isDhizukuAlive
+import com.looker.droidify.installer.installers.dhizuku.isDhizukuInstalled
 import com.looker.droidify.installer.model.InstallState
 import com.looker.droidify.installer.model.installFrom
 import com.looker.droidify.model.InstalledItem
@@ -28,7 +30,8 @@ import com.looker.droidify.utility.common.extension.asStateFlow
 import com.looker.droidify.utility.extension.combine
 import dagger.hilt.android.lifecycle.HiltViewModel
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.mapNotNull
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
@@ -48,9 +51,9 @@ class AppDetailViewModel @Inject constructor(
         savedStateHandle.getStateFlow(ARG_REPO_ADDRESS, null)
 
     val installerState: StateFlow<InstallState?> =
-        installer.state.mapNotNull { stateMap ->
+        installer.state.map { stateMap ->
             stateMap[packageName.toPackageName()]
-        }.asStateFlow(null)
+        }.asStateFlow(null, started = SharingStarted.Eagerly)
 
     val customButtons: StateFlow<List<CustomButton>> = customButtonRepository.buttons
         .asStateFlow(emptyList())
@@ -79,6 +82,7 @@ class AppDetailViewModel @Inject constructor(
                 allowIncompatibleVersions = settings.incompatibleVersions,
                 isSelf = packageName == BuildConfig.APPLICATION_ID,
                 addressIfUnavailable = suggestedAddress,
+                installerType = settings.installerType,
             )
         }.asStateFlow(AppDetailUiState())
 
@@ -86,24 +90,49 @@ class AppDetailViewModel @Inject constructor(
         val isSelected =
             runBlocking { settingsRepository.getInitial().installerType == InstallerType.SHIZUKU }
         if (!isSelected) return null
-        val isAlive = isShizukuAlive()
-        val isSuiAvailable = isSuiAvailable()
-        if (isSuiAvailable) return null
+        if (isSuiAvailable()) return null
 
-        val isGranted = if (isAlive) {
-            if (isShizukuGranted()) {
-                true
-            } else {
-                runBlocking { requestPermissionListener() }
-            }
-        } else {
-            false
-        }
+        val installed = isShizukuInstalled(context)
+        val alive = isShizukuAlive()
+        val granted = isShizukuGranted()
+        if (installed && alive && granted) return null
         return ShizukuState(
-            isNotInstalled = !isShizukuInstalled(context),
-            isNotGranted = !isGranted,
-            isNotAlive = !isAlive,
+            isNotInstalled = !installed,
+            isNotAlive = installed && !alive,
+            isNotGranted = alive && !granted,
         )
+    }
+
+    suspend fun prepareDhizuku(context: Context): DhizukuState? {
+        if (settingsRepository.getInitial().installerType != InstallerType.DHIZUKU) return null
+
+        if (!isDhizukuInstalled(context)) {
+            return DhizukuState(
+                isNotInstalled = true,
+                isNotAlive = false,
+                isNotGranted = false,
+            )
+        }
+        if (!ensureDhizukuInstallerReady(context)) {
+            return when {
+                !isDhizukuInstalled(context) -> DhizukuState(
+                    isNotInstalled = true,
+                    isNotAlive = false,
+                    isNotGranted = false,
+                )
+                !isDhizukuAlive(context) -> DhizukuState(
+                    isNotInstalled = false,
+                    isNotAlive = true,
+                    isNotGranted = false,
+                )
+                else -> DhizukuState(
+                    isNotInstalled = false,
+                    isNotAlive = false,
+                    isNotGranted = true,
+                )
+            }
+        }
+        return null
     }
 
     fun setDefaultInstaller() {
@@ -146,6 +175,8 @@ class AppDetailViewModel @Inject constructor(
     }
 }
 
+typealias DhizukuState = ShizukuState
+
 data class ShizukuState(
     val isNotInstalled: Boolean,
     val isNotGranted: Boolean,
@@ -165,4 +196,5 @@ data class AppDetailUiState(
     val isFavourite: Boolean = false,
     val allowIncompatibleVersions: Boolean = false,
     val addressIfUnavailable: String? = null,
+    val installerType: InstallerType = InstallerType.Default,
 )

--- a/app/src/main/kotlin/com/looker/droidify/ui/appDetail/DhizukuErrorDialog.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appDetail/DhizukuErrorDialog.kt
@@ -1,0 +1,36 @@
+package com.looker.droidify.ui.appDetail
+
+import android.content.Context
+import com.google.android.material.dialog.MaterialAlertDialogBuilder
+import com.looker.droidify.R.string as stringRes
+
+fun dhizukuDialog(
+    context: Context,
+    dhizukuState: DhizukuState,
+    openDhizuku: () -> Unit,
+    switchInstaller: () -> Unit,
+) = with(MaterialAlertDialogBuilder(context)) {
+    when {
+        dhizukuState.isNotAlive -> {
+            setTitle(stringRes.error_dhizuku_service_unavailable)
+            setMessage(stringRes.error_dhizuku_not_running_DESC)
+        }
+
+        dhizukuState.isNotGranted -> {
+            setTitle(stringRes.error_dhizuku_not_granted)
+            setMessage(stringRes.error_dhizuku_not_granted_DESC)
+        }
+
+        dhizukuState.isNotInstalled -> {
+            setTitle(stringRes.error_dhizuku_not_installed)
+            setMessage(stringRes.error_dhizuku_not_installed_DESC)
+        }
+    }
+    setPositiveButton(stringRes.switch_to_default_installer) { _, _ ->
+        switchInstaller()
+    }
+    setNeutralButton(stringRes.open_dhizuku) { _, _ ->
+        openDhizuku()
+    }
+    setNegativeButton(stringRes.cancel, null)
+}

--- a/app/src/main/kotlin/com/looker/droidify/ui/appList/AppListViewModel.kt
+++ b/app/src/main/kotlin/com/looker/droidify/ui/appList/AppListViewModel.kt
@@ -65,9 +65,7 @@ class AppListViewModel
     val syncConnection = Connection(SyncService::class.java)
 
     fun updateAll() {
-        viewModelScope.launch {
-            syncConnection.binder?.updateAllApps()
-        }
+        syncConnection.binder?.updateAllApps()
     }
 
     fun setSection(newSection: ProductItem.Section) {

--- a/app/src/main/kotlin/com/looker/droidify/utility/extension/Connection.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/extension/Connection.kt
@@ -1,37 +1,89 @@
 package com.looker.droidify.utility.extension
 
+import android.util.Log
 import com.looker.droidify.model.InstalledItem
 import com.looker.droidify.model.Product
+import com.looker.droidify.model.Release
 import com.looker.droidify.model.Repository
 import com.looker.droidify.model.findSuggested
 import com.looker.droidify.service.Connection
 import com.looker.droidify.service.DownloadService
+import com.looker.droidify.utility.common.log
 import com.looker.droidify.utility.extension.android.Android
+
+private const val TAG = "DroidifyUpdateAll"
 
 fun Connection<DownloadService.Binder, DownloadService>.startUpdate(
     packageName: String,
     installedItem: InstalledItem?,
     products: List<Pair<Product, Repository>>,
 ) {
-    if (binder == null || products.isEmpty()) return
+    val params = resolveUpdateParams(packageName, installedItem, products) ?: return
+    requireNotNull(binder).enqueue(
+        packageName = packageName,
+        name = params.product.name,
+        repository = params.repository,
+        release = params.release,
+        isUpdate = installedItem != null,
+    )
+}
 
-    val (product, repository) = products.findSuggested(installedItem) ?: return
+suspend fun Connection<DownloadService.Binder, DownloadService>.startUpdateAndAwait(
+    packageName: String,
+    installedItem: InstalledItem?,
+    products: List<Pair<Product, Repository>>,
+): Boolean {
+    val params = resolveUpdateParams(packageName, installedItem, products) ?: return false
+    return requireNotNull(binder).enqueueAndAwait(
+        packageName = packageName,
+        name = params.product.name,
+        repository = params.repository,
+        release = params.release,
+        isUpdate = installedItem != null,
+    )
+}
+
+private data class UpdateParams(
+    val product: Product,
+    val repository: Repository,
+    val release: Release,
+)
+
+private fun Connection<DownloadService.Binder, DownloadService>.resolveUpdateParams(
+    packageName: String,
+    installedItem: InstalledItem?,
+    products: List<Pair<Product, Repository>>,
+): UpdateParams? {
+    if (binder == null) {
+        log("startUpdate skipped $packageName: binder null", TAG, Log.ERROR)
+        return null
+    }
+    if (products.isEmpty()) {
+        log("startUpdate skipped $packageName: no products", TAG, Log.WARN)
+        return null
+    }
+
+    val (product, repository) = products.findSuggested(installedItem) ?: run {
+        log("startUpdate skipped $packageName: findSuggested returned null", TAG, Log.WARN)
+        return null
+    }
 
     val compatibleReleases = product.selectedReleases
         .filter { installedItem == null || installedItem.signature == it.signature }
-        .ifEmpty { return }
+    if (compatibleReleases.isEmpty()) {
+        log("startUpdate skipped $packageName: no compatible release", TAG, Log.WARN)
+        return null
+    }
 
     val selectedRelease = compatibleReleases.singleOrNull() ?: compatibleReleases.run {
         filter { Android.primaryPlatform in it.platforms }.minByOrNull { it.platforms.size }
             ?: minByOrNull { it.platforms.size }
             ?: firstOrNull()
-    } ?: return
+    }
+    if (selectedRelease == null) {
+        log("startUpdate skipped $packageName: no selected release", TAG, Log.WARN)
+        return null
+    }
 
-    requireNotNull(binder).enqueue(
-        packageName = packageName,
-        name = product.name,
-        repository = repository,
-        release = selectedRelease,
-        isUpdate = installedItem != null,
-    )
+    return UpdateParams(product, repository, selectedRelease)
 }

--- a/app/src/main/kotlin/com/looker/droidify/utility/notifications/InstallNotification.kt
+++ b/app/src/main/kotlin/com/looker/droidify/utility/notifications/InstallNotification.kt
@@ -71,6 +71,13 @@ fun Context.createInstallNotification(
                             appName
                     }
 
+                    InstallState.Uninstalling -> {
+                        setSmallIcon(R.drawable.ic_delete)
+                        setProgress(-1, -1, true)
+                        getString(R.string.uninstalling) to
+                            appName
+                    }
+
                     InstallState.Installed -> {
                         setTimeoutAfter(SUCCESS_TIMEOUT)
                         setSmallIcon(R.drawable.ic_check)

--- a/app/src/main/res/values-ja/strings.xml
+++ b/app/src/main/res/values-ja/strings.xml
@@ -171,6 +171,16 @@
     <string name="session_installer">セッションインストーラー</string>
     <string name="root_installer">Root インストーラー</string>
     <string name="shizuku_installer">Shizuku インストーラー</string>
+    <string name="dhizuku_installer">Dhizuku インストーラー</string>
+    <string name="dhizuku_not_alive">Dhizuku が動作していません</string>
+    <string name="dhizuku_not_installed">Dhizuku はインストールされていません</string>
+    <string name="error_dhizuku_service_unavailable">Dhizuku サービスが動作していません</string>
+    <string name="error_dhizuku_not_running_DESC">Dhizuku サービスが動作していません</string>
+    <string name="error_dhizuku_not_granted">Dhizuku の権限が付与されていません</string>
+    <string name="error_dhizuku_not_granted_DESC">Dhizuku の権限が付与されていません</string>
+    <string name="error_dhizuku_not_installed">Dhizuku がインストールされていません</string>
+    <string name="error_dhizuku_not_installed_DESC">Dhizuku はインストールされていません</string>
+    <string name="open_dhizuku">Dhizuku を開く</string>
     <string name="plus_more_FORMAT">さらに %d 件</string>
     <string name="proxy_host">プロキシホスト</string>
     <string name="proxy_port">プロキシポート</string>
@@ -179,6 +189,7 @@
     <string name="auto_update">アプリの自動更新</string>
     <string name="auto_update_apps">アップデートを自動的にインストールします</string>
     <string name="installing">インストール中</string>
+    <string name="uninstalling">アンインストール中</string>
     <string name="waiting_to_start_installation">インストール開始を待機中…</string>
     <string name="favourites">お気に入り</string>
     <string name="material_you">Material You</string>
@@ -209,6 +220,7 @@
     <string name="import_repos_DESC">ファイルから全てのリポジトリをインポートする</string>
     <string name="uninstalled_application">アンインストール</string>
     <string name="uninstalled_application_DESC">%s をアンインストールしました</string>
+    <string name="uninstall_application_DESC">「%s」をアンインストールしますか？</string>
     <string name="installation_failed">インストールに失敗しました</string>
     <string name="installation_failed_DESC">%s のインストールに失敗しました</string>
     <string name="ignore_signature_summary">LSPosedユーザー、上級ユーザー向けに、apkをインストールする際の署名の検証を無視します</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -115,6 +115,15 @@
     <string name="root_installer">Root installer</string>
     <string name="shizuku_installer">Shizuku/Sui installer</string>
     <string name="dhizuku_installer">Dhizuku installer</string>
+    <string name="dhizuku_not_alive">Dhizuku isn\'t running</string>
+    <string name="dhizuku_not_installed">Dhizuku isn\'t installed</string>
+    <string name="error_dhizuku_service_unavailable">Dhizuku service not running</string>
+    <string name="error_dhizuku_not_running_DESC">The Dhizuku service isn\'t running</string>
+    <string name="error_dhizuku_not_granted">No Dhizuku permission granted</string>
+    <string name="error_dhizuku_not_granted_DESC">The Dhizuku permission hasn\'t been granted</string>
+    <string name="error_dhizuku_not_installed">Dhizuku not installed</string>
+    <string name="error_dhizuku_not_installed_DESC">Dhizuku isn\'t installed</string>
+    <string name="open_dhizuku">Open Dhizuku</string>
     <string name="shizuku_legacy_installer">Shizuku/Sui legacy installer</string>
     <string name="shizuku_not_alive">Shizuku/Sui isn\'t running</string>
     <string name="shizuku_not_installed">Shizuku/Sui isn\'t installed</string>
@@ -125,6 +134,7 @@
     <string name="installation_failed_DESC">Failed to install %s</string>
     <string name="uninstalled_application">Uninstalled</string>
     <string name="uninstalled_application_DESC">%s has been uninstalled</string>
+    <string name="uninstall_application_DESC">Uninstall %s?</string>
     <string name="integrity_check_error_DESC">Couldn\'t check integrity</string>
     <string name="invalid_address">Invalid address</string>
     <string name="invalid_fingerprint_format">Invalid fingerprint format</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -114,6 +114,7 @@
     <string name="session_installer">Session installer</string>
     <string name="root_installer">Root installer</string>
     <string name="shizuku_installer">Shizuku/Sui installer</string>
+    <string name="dhizuku_installer">Dhizuku installer</string>
     <string name="shizuku_legacy_installer">Shizuku/Sui legacy installer</string>
     <string name="shizuku_not_alive">Shizuku/Sui isn\'t running</string>
     <string name="shizuku_not_installed">Shizuku/Sui isn\'t installed</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -119,6 +119,7 @@
     <string name="shizuku_not_installed">Shizuku/Sui isn\'t installed</string>
     <string name="installed">Installed</string>
     <string name="installing">Installing</string>
+    <string name="uninstalling">Uninstalling</string>
     <string name="installation_failed">Installation failed</string>
     <string name="installation_failed_DESC">Failed to install %s</string>
     <string name="uninstalled_application">Uninstalled</string>

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,7 @@ ktor = "3.4.1"
 libsu = "6.0.0"
 room = "2.8.4"
 shizuku = "13.0.0"
+dhizuku = "2.5.4"
 image-viewer = "1.0.1"
 junit-jupiter = "6.0.3"
 robolectric = "4.16.1"
@@ -90,6 +91,7 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-test = { group = "androidx.room", name = "room-testing", version.ref = "room" }
 shizuku-api = { group = "dev.rikka.shizuku", name = "api", version.ref = "shizuku" }
 shizuku-provider = { group = "dev.rikka.shizuku", name = "provider", version.ref = "shizuku" }
+dhizuku-api = { module = "io.github.iamr0s:Dhizuku-API", version.ref = "dhizuku" }
 image-viewer = { module = "com.github.stfalcon-studio:StfalconImageViewer", version.ref = "image-viewer" }
 junit-bom = { group = "org.junit", name = "junit-bom", version.ref = "junit-jupiter" }
 junit-jupiter = { group = "org.junit.jupiter", name = "junit-jupiter" }


### PR DESCRIPTION
## Summary
- `DownloadService.enqueueAndAwait()` / `Connection.startUpdateAndAwait()`
- Sequential update-all batch in `SyncService` with Dhizuku readiness gates
- `UpdateAllProgress` for UI (consumed in PR E)

**PR D of 5** — replacement stack for closed #1339.

**Depends on:** #1344 (PR B) + #1345 (PR C). Rebase onto `main` as predecessors merge.

## Test plan
- [x] `./gradlew :app:assembleDebug`
- [x] `./gradlew :app:testDebugUnitTest`
- [x] Update-all with Shizuku/Root (regression)
- [x] Update-all with Dhizuku after full stack merges


Made with [Cursor](https://cursor.com)