### PR TITLE
fix: add installed apps to the launcher home screen

### DIFF
--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/root/RootInstaller.kt
@@ -22,6 +22,7 @@ class RootInstaller(private val context: Context) : Installer {
             releaseFile.absolutePath,
             currentUser(),
             context.packageName,
+            installReasonFlag(),
             releaseFile.length(),
         )
         Shell.cmd(installCommand).submit { shellResult ->
@@ -42,8 +43,17 @@ class RootInstaller(private val context: Context) : Installer {
     override fun close() {}
 }
 
-private const val INSTALL_COMMAND = "cat %s | pm install --user %s -i %s -t -r -S %s"
+private const val INSTALL_COMMAND = "cat %s | pm install --user %s -i %s %s -t -r -S %s"
 private const val DELETE_COMMAND = "%s rm %s"
+
+/**
+ * Marks the install as user-initiated (`INSTALL_REASON_USER` = 4). `pm install` creates a regular
+ * `PackageInstaller` session internally, but defaults its reason to `INSTALL_REASON_UNKNOWN`, and
+ * launchers (e.g. AOSP Launcher3's `SessionCommitReceiver`) only auto-add a home screen icon for
+ * user-initiated sessions. `pm` only knows this option since Android O; the empty string pre-O
+ * leaves a harmless double space in the command.
+ */
+private fun installReasonFlag() = if (SdkCheck.isOreo) "--install-reason 4" else ""
 
 /** Returns the path of either toybox or busybox, or empty string if not found. */
 private fun utilBox(): String {

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/session/SessionInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/session/SessionInstaller.kt
@@ -5,6 +5,7 @@ import android.app.PendingIntent
 import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageInstaller
+import android.content.pm.PackageManager
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -30,6 +31,7 @@ class SessionInstaller(private val context: Context) : Installer {
         private val flags = if (SdkCheck.isSnowCake) PendingIntent.FLAG_MUTABLE else 0
         private val sessionParams =
             PackageInstaller.SessionParams(PackageInstaller.SessionParams.MODE_FULL_INSTALL).apply {
+                setInstallReason(PackageManager.INSTALL_REASON_USER)
                 sdkAbove(sdk = Build.VERSION_CODES.S) {
                     setRequireUserAction(PackageInstaller.SessionParams.USER_ACTION_NOT_REQUIRED)
                 }

--- a/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
+++ b/app/src/main/kotlin/com/looker/droidify/installer/installers/shizuku/ShizukuInstaller.kt
@@ -34,12 +34,17 @@ class ShizukuInstaller(private val context: Context) : Installer {
             if (cont.isCompleted) return@suspendCancellableCoroutine
             val installerPackage = context.packageName
             file.inputStream().use {
-                val createCommand =
-                    if (SdkCheck.isNougat) {
+                // INSTALL_REASON_USER (4): launchers only auto-add a home screen icon for
+                // user-initiated install sessions; `pm` knows the option since Android O.
+                val createCommand = when {
+                    SdkCheck.isOreo ->
+                        "pm install-create --user current -i $installerPackage" +
+                            " --install-reason 4 -S $fileSize"
+                    SdkCheck.isNougat ->
                         "pm install-create --user current -i $installerPackage -S $fileSize"
-                    } else {
+                    else ->
                         "pm install-create -i $installerPackage -S $fileSize"
-                    }
+                }
                 val createResult = exec(createCommand)
                 sessionId = SESSION_ID_REGEX.find(createResult.out)?.value
                     ?: run {


### PR DESCRIPTION
## 🐛 Problem

Apps installed via Droid-ify were not appearing on the launcher home screen, while the same app installed from another store (e.g. Aurora Store) would be added automatically. ❌

## 🔍 Root cause

AOSP Launcher3's `SessionCommitReceiver` only adds the icon to the home screen **if** the install session has `INSTALL_REASON_USER` as its install reason. None of the three installer backends were setting it:

- 📦 **Session** — reason defaulted to `INSTALL_REASON_UNKNOWN`
- 🔑 **Root** / 🧩 **Shizuku** — the `pm` command was missing the flag

→ The launcher silently ignored the committed session: the app was installed correctly, but no shortcut was ever created.

## ✅ Fix

- `SessionInstaller` → `setInstallReason(INSTALL_REASON_USER)`
- `RootInstaller` & `ShizukuInstaller` → added `--install-reason 4` (Android 8+)

Three lines total, no behavioral change outside this case. ✨

## 📱 Testing

Tested on physical devices (LineageOS / Android 13 and Android 16): the icon now correctly appears on the home screen after installation, in both **session** and **root** mode. ✅

Properly fixes #807, #113 which was closed as completed but never actually resolved.
